### PR TITLE
modules/ly: log to syslog by default

### DIFF
--- a/modules/services/ly/default.nix
+++ b/modules/services/ly/default.nix
@@ -79,6 +79,10 @@ in
       brightness_up_cmd = lib.mkDefault "${lib.getExe brightnessctl} -q s +10%";
       brightness_down_cmd = lib.mkDefault "${lib.getExe brightnessctl} -q s 10%-";
     }
+    // lib.optionalAttrs (lib.versionAtLeast cfg.package.version "1.5.0") {
+      # write to syslog
+      ly_log = lib.mkDefault null;
+    }
     // lib.optionalAttrs config.services.xserver.enable or false {
       xsessions = "/run/current-system/sw/share/xsessions";
       xauth_cmd = "${pkgs.xorg.xauth}/bin/xauth";


### PR DESCRIPTION
`ly` didn't support log rotation - support has been [added](https://codeberg.org/fairyglade/ly/issues/965) in version `1.5.0`

this is desirable for a few reasons, the most important of which is log rotation

cc @chocoblocko9