### PR TITLE
fix(etc): /etc/os-release text updated

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -37,14 +37,16 @@ in
     '';
 
     environment.etc.os-release.text = ''
-      ANSI_COLOR="1;34"
+      ANSI_COLOR="0;38;2;231;56;71"
+      BUG_REPORT_URL="https://github.com/finix-community/finix/issues/"
       DEFAULT_HOSTNAME=finix
-      DOCUMENTATION_URL="https://nixos.org/learn.html"
-      HOME_URL="https://nixos.org/"
+      HOME_URL="https://github.com/finix-community/finix/"
       ID=finix
       LOGO=finix-logo
       NAME=finix
       PRETTY_NAME="finix 25.05"
+      VENDOR_NAME=finix
+      VENDOR_URL="https://github.com/finix-community/finix/"
       VERSION="25.05"
       VERSION_ID="25.05"
     '';


### PR DESCRIPTION
>[!TIP]
> roses are red,
> violets are blue,
> `/etc/os-release` is good,
> but there is always a room for improve. 

```Nix
ANSI_COLOR="0;38;2;231;56;71"
```
is true to `finix-logo` red color;
all links are valid for `/etc/os-release` strings;
not updating version itself;