### PR TITLE
modules/keventd: init

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -21,6 +21,7 @@ let
       # required modules - included by default
       "dbus"
       "elogind"
+      "keventd"
       "mdevd"
       "seatd"
       "udev"
@@ -52,6 +53,7 @@ in
       ./security
       ./services/dbus
       ./services/elogind
+      ./services/keventd
       ./services/mdevd
       ./services/seatd
       ./services/udev

--- a/modules/finit/initrd.nix
+++ b/modules/finit/initrd.nix
@@ -248,6 +248,7 @@ in
           task [S] name:fs-import tty:@console \
             ${lib.optionalString config.services.mdevd.enable "<run/coldplug/success>"} \
             ${lib.optionalString config.services.udev.enable "<run/udevadm:5/success>"} \
+            ${lib.optionalString config.services.keventd.enable "<service/keventd/ready>"} \
             finix-fs-import
 
           task [S] name:mount-all <task/fs-import/success> finix-mount-all
@@ -258,6 +259,10 @@ in
 
           ${lib.optionalString config.services.udev.enable ''
             service [S] <!> notify:s6 /bin/udevd --ready-notify=%n
+          ''}
+
+          ${lib.optionalString config.services.keventd.enable ''
+            service [S] name:keventd notify:pid <!> keventd -n -c
           ''}
 
           run [1] name:switch-root finix-switch-root
@@ -281,9 +286,13 @@ in
       }
       {
         target = "/etc/group";
-        source = pkgs.writeText "group" ''
-          root:x:0:
-        '';
+        source = pkgs.writeText "group" (
+          lib.concatStringsSep "\n" (
+            lib.concatMap (g: lib.optionals (g.gid != null) [ "${g.name}:x:${toString g.gid}" ]) (
+              lib.attrValues config.users.groups
+            )
+          )
+        );
       }
       {
         target = "/etc/shadow";
@@ -314,6 +323,12 @@ in
       { source = "${config.finit.package}/lib/finit/rescue.conf"; }
       { source = "${config.finit.package}/lib/finit/tmpfiles.d"; }
       { source = "${config.finit.package}/lib/tmpfiles.d"; }
+    ]
+    ++ lib.optionals config.services.keventd.enable [
+      {
+        target = "/etc/udev/rules.d"; # keventd reads /etc - avoids collision
+        source = "${config.finit.package}/lib/udev/rules.d";
+      }
     ];
   };
 }

--- a/modules/programs/brightnessctl/default.nix
+++ b/modules/programs/brightnessctl/default.nix
@@ -23,7 +23,7 @@ in
       type = lib.types.package;
       default = package.override {
         logindSupport = config.services.elogind.enable;
-        udevSupport = config.services.udev.enable;
+        udevSupport = config.services.udev.enable || config.services.keventd.enable;
 
         systemdLibs = config.services.elogind.package;
       };

--- a/modules/programs/hyprland/default.nix
+++ b/modules/programs/hyprland/default.nix
@@ -17,16 +17,16 @@ let
     Keywords=tiling;wayland;compositor;
   '';
 
-  # libudev-zero is a hard requirement when running mdevd
+  # libudev-zero is a hard requirement when running mdevd or keventd
   libinput = pkgs.libinput.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       udev = pkgs.libudev-zero;
       wacomSupport = false;
     }
   );
 
   aquamarine = pkgs.aquamarine.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       inherit libinput;
 
       udev = pkgs.libudev-zero;
@@ -49,7 +49,7 @@ in
         inherit aquamarine libinput;
 
         # since we're recompiling go ahead and disable systemd
-        withSystemd = !config.services.mdevd.enable;
+        withSystemd = !(config.services.mdevd.enable || config.services.keventd.enable);
       };
       defaultText = lib.literalExpression "pkgs.hyprland";
       description = ''

--- a/modules/programs/labwc/default.nix
+++ b/modules/programs/labwc/default.nix
@@ -17,9 +17,9 @@ let
     Type=Application
   '';
 
-  # libudev-zero is a hard requirement when running mdevd
+  # libudev-zero is a hard requirement when running mdevd or keventd
   libinput = pkgs.libinput.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       udev = pkgs.libudev-zero;
       wacomSupport = false;
     }

--- a/modules/programs/lxqt/default.nix
+++ b/modules/programs/lxqt/default.nix
@@ -29,7 +29,7 @@ let
   '';
 
   libinput = pkgs.libinput.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       udev = pkgs.libudev-zero;
       wacomSupport = false;
     }

--- a/modules/programs/mangowc/default.nix
+++ b/modules/programs/mangowc/default.nix
@@ -18,9 +18,9 @@ let
     Type=Application
   '';
 
-  # libudev-zero is a hard requirement when running mdevd
+  # libudev-zero is a hard requirement when running mdevd or keventd
   libinput = pkgs.libinput.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       udev = pkgs.libudev-zero;
       wacomSupport = false;
     }

--- a/modules/programs/niri/default.nix
+++ b/modules/programs/niri/default.nix
@@ -16,18 +16,20 @@ let
     Type=Application
   '';
 
-  overrideAttrs = lib.optionalAttrs config.services.mdevd.enable {
-    eudev = pkgs.libudev-zero;
+  overrideAttrs =
+    # libudev-zero is a hard requirement when running mdevd or keventd
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
+      eudev = pkgs.libudev-zero;
 
-    # since we're recompiling go ahead and disable systemd
-    withSystemd = false;
-
-    # libudev-zero is a hard requirement when running mdevd
-    libinput = pkgs.libinput.override {
-      udev = pkgs.libudev-zero;
-      wacomSupport = false;
+      libinput = pkgs.libinput.override {
+        udev = pkgs.libudev-zero;
+        wacomSupport = false;
+      };
+    }
+    // lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
+      # since we're recompiling go ahead and disable systemd
+      withSystemd = false;
     };
-  };
 in
 {
   options.programs.niri = {

--- a/modules/programs/regreet/default.nix
+++ b/modules/programs/regreet/default.nix
@@ -11,9 +11,9 @@ let
 
   configFile = format.generate "regreet.toml" cfg.settings;
 
-  # libudev-zero is a hard requirement when running mdevd
+  # libudev-zero is a hard requirement when running mdevd or keventd
   libinput = pkgs.libinput.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       udev = pkgs.libudev-zero;
       wacomSupport = false;
     }
@@ -27,9 +27,9 @@ let
   };
 
   xinit' = pkgs.xinit.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       xorg-server = pkgs.xorg-server.override (
-        lib.optionalAttrs config.services.mdevd.enable {
+        lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
           udev = pkgs.libudev-zero;
         }
       );

--- a/modules/programs/sway/default.nix
+++ b/modules/programs/sway/default.nix
@@ -16,9 +16,9 @@ let
     DesktopNames=sway;wlroots
   '';
 
-  # libudev-zero is a hard requirement when running mdevd
+  # libudev-zero is a hard requirement when running mdevd or keventd
   libinput = pkgs.libinput.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       udev = pkgs.libudev-zero;
       wacomSupport = false;
     }
@@ -35,7 +35,7 @@ let
     inherit libinput wlroots_0_20;
 
     # since we're recompiling go ahead and disable systemd
-    systemdSupport = !config.services.mdevd.enable;
+    systemdSupport = !(config.services.mdevd.enable || config.services.keventd.enable);
   };
 in
 {

--- a/modules/programs/tuigreet/default.nix
+++ b/modules/programs/tuigreet/default.nix
@@ -9,9 +9,9 @@ let
   cfg = config.programs.tuigreet;
 
   xinit' = pkgs.xinit.override (
-    lib.optionalAttrs config.services.mdevd.enable {
+    lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
       xorg-server = pkgs.xorg-server.override (
-        lib.optionalAttrs config.services.mdevd.enable {
+        lib.optionalAttrs (config.services.mdevd.enable || config.services.keventd.enable) {
           udev = pkgs.libudev-zero;
         }
       );

--- a/modules/services/keventd/default.nix
+++ b/modules/services/keventd/default.nix
@@ -1,0 +1,134 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.keventd;
+in
+{
+  options.services.keventd = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable [keventd](${pkgs.finit.meta.homepage}) as a system service.
+      '';
+    };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable debug logging.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      description = ''
+        Additional arguments to pass to `keventd`.
+      '';
+    };
+
+    path = lib.mkOption {
+      type = with lib.types; listOf path;
+      default = [ ];
+      description = ''
+        Packages added to the {env}`PATH` environment variable when
+        executing programs from Udev rules.
+
+        coreutils, gnu{sed,grep}, util-linux
+        automatically included.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.finit.package.version "5.0";
+        message = "finit version must be at least 5.0";
+      }
+    ];
+
+    services.keventd.extraArgs = [
+      "-c"
+      (if cfg.debug then "-d" else "-n")
+    ];
+
+    services.keventd.path = [
+      config.programs.coreutils.package
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.kmod
+      pkgs.util-linux
+    ];
+
+    # contribute finit's bundled rules to the udev packages list.
+    services.udev.packages = [ config.finit.package ];
+
+    environment.etc."udev/rules.d".source =
+      pkgs.runCommand "keventd-rules"
+        {
+          __structuredAttrs = true;
+          preferLocalBuild = true;
+          allowSubstitutes = false;
+          packages = lib.unique config.services.udev.packages;
+        }
+        ''
+          mkdir -p $out
+          shopt -s nullglob
+
+          for i in "''${packages[@]}"; do
+            echo "Adding rules for package $i"
+            for j in $i/{etc,lib,var/lib}/udev/rules.d/*; do
+              echo "Copying $j to $out/$(basename $j)"
+              cat $j > $out/$(basename $j)
+            done
+          done
+
+          for i in $out/*.rules; do
+            substituteInPlace $i \
+              --replace-quiet \"/sbin/modprobe \"${pkgs.kmod}/bin/modprobe \
+              --replace-quiet \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
+              --replace-quiet \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
+              --replace-quiet \"/bin/mount \"${pkgs.util-linux}/bin/mount \
+              --replace-quiet /usr/bin/readlink ${lib.getExe' config.programs.coreutils.package "readlink"} \
+              --replace-quiet /usr/bin/cat ${lib.getExe' config.programs.coreutils.package "cat"} \
+              --replace-quiet /usr/bin/basename ${lib.getExe' config.programs.coreutils.package "basename"} 2>/dev/null
+          done
+        '';
+
+    finit.services.keventd = {
+      inherit (cfg) path;
+
+      description = "device event daemon (keventd)";
+      command = "${config.finit.package}/libexec/finit/keventd " + lib.escapeShellArgs cfg.extraArgs;
+      runlevels = "S12345789";
+      cgroup.name = "init";
+      notify = "pid";
+      log = true;
+    };
+
+    # TODO: add finit.services.reloadTriggers option
+    environment.etc."finit.d/keventd.conf".text = lib.mkAfter ''
+
+      # reload trigger
+      # ${config.environment.etc."udev/rules.d".source}
+    '';
+
+    # TODO: share between device managers
+    system.activation.scripts.keventd = lib.mkIf config.boot.kernel.enable {
+      text = ''
+        # Allow the kernel to find our firmware.
+        if [ -e /sys/module/firmware_class/parameters/path ]; then
+          echo -n "${config.hardware.firmware}/lib/firmware" > /sys/module/firmware_class/parameters/path
+        fi
+      '';
+    };
+  };
+}

--- a/modules/services/rsyslog/default.nix
+++ b/modules/services/rsyslog/default.nix
@@ -53,7 +53,8 @@ in
       runlevels = "S0123456789";
       conditions =
         lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
-        ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
+        ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
+        ++ lib.optionals config.services.keventd.enable [ "pid/keventd" ];
       command = "${pkgs.rsyslog-light}/bin/rsyslogd -n -d -f ${configFile}";
     };
 

--- a/modules/services/sysklogd/default.nix
+++ b/modules/services/sysklogd/default.nix
@@ -63,7 +63,8 @@ in
       runlevels = "S0123456789";
       conditions =
         lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
-        ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
+        ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
+        ++ lib.optionals config.services.keventd.enable [ "pid/keventd" ];
       command = "${cfg.package}/bin/syslogd -F";
       notify = "pid";
     };


### PR DESCRIPTION
testing https://github.com/finit-project/finit/pull/491 with this config:

```nix
{
  finit.package = pkgs.finit.overrideAttrs (o: {
    version = "5.0";
    src = pkgs.fetchFromGitHub {
      owner = "finit-project";
      repo = "finit";
      rev = "devman";
      sha256 = "sha256-HmZPAhnZD0AIuzvkfiwjMudeYrjEIlDXUclsqXvNTI4=";
    };

    buildInputs = o.buildInputs ++ [ pkgs.util-linuxMinimal.dev ];

    postPatch = (o.postPatch or "") + ''
      substituteInPlace keventd/uevent.c \
        --replace-fail '"/sbin/modprobe", "modprobe"' '"${pkgs.kmod}/bin/modprobe", "modprobe"' \
        --replace-fail '"/usr/lib/firmware/' '"/run/current-system/firmware/lib/firmware/'

      substituteInPlace keventd/builtin.c \
        --replace-fail  '"/lib/udev/hwdb.d"' '"/run/current-system/sw/lib/udev/hwdb.d"' \
        --replace-fail  '"/usr/share/hwdata/usb.ids"' '"${pkgs.hwdata}/share/hwdata/usb.ids"'
    '';
  });

  specialisation.keventd = {
    services.keventd.enable = lib.mkForce true;
    services.mdevd.enable = lib.mkForce false;
    services.udev.enable = lib.mkForce false;

    services.seatd.enable = lib.mkForce true;
    services.elogind.enable = lib.mkForce false;

    services.iwd.enable = lib.mkForce true;
  };
}
```

working quite well so far :sunglasses: