### PR TITLE
feat(security): common-bwrap function init

### DIFF
--- a/modules/security/common-bwrap.nix
+++ b/modules/security/common-bwrap.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  bwrap = {
+    base = [     
+      "--unshare-all"
+      "--die-with-parent"
+      "--hostname sandbox"
+      "--proc /proc"
+      "--dev /dev"
+      "--seccomp 10"
+    ];
+
+    roSys = [
+      "--ro-bind /nix /nix"
+      "--ro-bind /etc/resolv.conf /etc/resolv.conf"
+    ] ++ (
+      lib.forEach [
+        "bin"
+        "lib"
+        "sbin"
+        "etc"
+        "share"
+      ] (
+        dir: 
+          "--ro-bind ${config.environment.path}/${dir} /${dir}"
+      )
+    );
+
+    trap = pkgs.writeShellApplication {
+      name = "trap";
+      runtimeInputs = with pkgs; [
+        bubblewrap
+        busybox
+      ];
+
+      text = ''
+        
+        SANDBOX_RUN=''$(mktemp -d /run/user/''$(id -u)/sandbox.XXXXXXXXXX)
+
+        trap 'rm -rf "$SANDBOX_RUN"' EXIT INT TERM
+
+        BWRAP_ARGS="${lib.concatStringsSep " " (bwrap.base ++ bwrap.roSys)} --bind $SANDBOX_RUN /run --bind $SANDBOX_RUN /tmp"
+
+        exec 10<"${./common.bpf}"
+
+        exec env -i \
+            LANG="C.UTF-8" \
+            PATH="/bin:/sbin" \
+            bwrap ''$BWRAP_ARGS -- "''$@"
+      '';
+    };
+  };
+in
+  bwrap.trap

--- a/modules/security/common-bwrap.nix
+++ b/modules/security/common-bwrap.nix
@@ -41,11 +41,11 @@
         
         SANDBOX_RUN=''$(mktemp -d /run/user/''$(id -u)/sandbox.XXXXXXXXXX)
 
-        trap 'rm -rf "$SANDBOX_RUN"' EXIT INT TERM
+        trap 'rm -rf "''$SANDBOX_RUN"' EXIT INT TERM
 
-        BWRAP_ARGS="${lib.concatStringsSep " " (bwrap.base ++ bwrap.roSys)} --bind $SANDBOX_RUN /run --bind $SANDBOX_RUN /tmp"
+        BWRAP_ARGS="${lib.concatStringsSep " " (bwrap.base ++ bwrap.roSys)} --bind ''$SANDBOX_RUN /run --bind ''$SANDBOX_RUN /tmp"
 
-        exec 10<"${./common.bpf}"
+        exec 10<"''${./common.bpf}"
 
         exec env -i \
             LANG="C.UTF-8" \

--- a/modules/security/common-bwrap.nix
+++ b/modules/security/common-bwrap.nix
@@ -2,10 +2,13 @@
   config,
   pkgs,
   lib,
+
+  extraFlags ? [ ],
+  extraPaths ? [ ],
   ...
 }: let
   bwrap = {
-    base = [     
+    base = extraFlags ++ [     
       "--unshare-all"
       "--die-with-parent"
       "--hostname sandbox"
@@ -14,7 +17,7 @@
       "--seccomp 10"
     ];
 
-    roSys = [
+    roSys = extraPaths ++ [
       "--ro-bind /nix /nix"
       "--ro-bind /etc/resolv.conf /etc/resolv.conf"
     ] ++ (
@@ -55,4 +58,15 @@
     };
   };
 in
-  bwrap.trap
+  bwrap // {
+    override = args:
+      import ./common-bwrap.nix {
+        inherit
+          config
+          pkgs
+          lib
+          ;
+          extraFlags = extraFlags ++ (args.extraFlags or [ ]);
+          extraPaths = extraPaths ++ (args.extraPaths or [ ]);
+      };
+}

--- a/modules/security/default.nix
+++ b/modules/security/default.nix
@@ -2,5 +2,6 @@
   imports = [
     ./pam
     ./wrappers
+    ./common-bwrap.nix
   ];
 }


### PR DESCRIPTION
could be used as package before executable in `finit.services.<...>`
