### PR TITLE
modules/pipewire: init

### DIFF
--- a/modules/programs/pipewire/README.md
+++ b/modules/programs/pipewire/README.md
@@ -1,0 +1,15 @@
+# pipewire
+
+This module installs PipeWire as a standalone program and allows you to define configuration options for its various components, which are then serialized to PipeWire's native config format. Config files are then generated from these options and symlinked to the necessary directories that PipeWire expects. 
+
+## usage
+
+This module does not provide a system service like NixOS. Instead, you will need to run the `pipewire` command in an `autostart` script in your Wayland compositor or x11 window manager. Here is an example of what this might look like:
+
+```
+pipewire 2>&1 &
+sleep 0.5; wireplumber 2>&1 &
+sleep 0.5; pipewire-pulse 2>&1 &
+```
+
+The half a second sleep between starting `wireplumber` and `pipewire-pulse` is recommended to make sure `pipewire` has enough time to fully start up. This would normally be handled in service conditions.

--- a/modules/programs/pipewire/default.nix
+++ b/modules/programs/pipewire/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./pipewire.nix
+    ./wireplumber.nix
+  ];
+}

--- a/modules/programs/pipewire/pipewire.nix
+++ b/modules/programs/pipewire/pipewire.nix
@@ -375,18 +375,10 @@ in
       pipewire.source = "${configs}/share/pipewire";
     };
 
-    /*
-      TODO wtf do i do here?? this isn't a service so it doesn't have an environment,
-      but you need this junk to let JACK run properly and make the system aware of
-      any LV2 / LADSPA plugins. BUUUTTT, if any other module for whatever reason
-      wants to overwrite these values then they are SOL unless they mkForce or mkDefault
-      it which is NOT ideal for what should be obvious reasons
-    */
-
-    # security.pam.environment = {
-    #   LD_LIBRARY_PATH.default = mkIf cfg.jack.enable [ "${cfg.package.jack}/lib" ];
-    #   LV2_PATH.default = "${lv2Plugins}/lib/lv2";
-    #   LADSPA_PATH.default = "${ladspaPlugins}/lib/ladspa";
-    # };
+    security.pam.environment = {
+      LD_LIBRARY_PATH.default = mkIf cfg.jack.enable [ "${cfg.package.jack}/lib" ];
+      LV2_PATH.default = [ "${lv2Plugins}/lib/lv2" ];
+      LADSPA_PATH.default = [ "${ladspaPlugins}/lib/ladspa" ];
+    };
   };
 }

--- a/modules/programs/pipewire/pipewire.nix
+++ b/modules/programs/pipewire/pipewire.nix
@@ -1,0 +1,385 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+with lib;
+let
+  inherit (lib.attrsets)
+    attrsToList
+    concatMapAttrs
+    ;
+  inherit (lib.lists)
+    optional
+    optionals
+    ;
+  inherit (lib.modules)
+    mkIf
+    ;
+  inherit (lib.options)
+    literalExpression
+    mkEnableOption
+    mkOption
+    ;
+  inherit (lib.strings)
+    concatMapStringsSep
+    optionalString
+    ;
+  inherit (lib.types)
+    attrsOf
+    listOf
+    package
+    ;
+
+  cfg = config.programs.pipewire;
+
+  json = pkgs.formats.json { };
+  mapToFiles =
+    location: config:
+    concatMapAttrs (name: value: {
+      "share/pipewire/${location}.conf.d/${name}.conf" = json.generate "${name}" value;
+    }) config;
+  extraConfigPkgFromFiles =
+    locations: filesSet:
+    pkgs.runCommand "pipewire-extra-config" { } ''
+      mkdir -p ${concatMapStringsSep " " (l: "$out/share/pipewire/${l}.conf.d") locations}
+      ${concatMapStringsSep ";" ({ name, value }: "ln -s ${value} $out/${name}") (attrsToList filesSet)}
+    '';
+  enable32BitAlsaPlugins =
+    cfg.alsa.support32Bit && pkgs.stdenv.hostPlatform.isx86_64 && pkgs.pkgsi686Linux.pipewire != null;
+
+  pipewire' =
+    (pkgs.pipewire.override (
+      lib.optionalAttrs config.services.mdevd.enable {
+        enableSystemd = false;
+        udev = pkgs.libudev-zero;
+      }
+    )).overrideAttrs
+      (o: {
+        # https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2398#note_2967898
+        patches =
+          o.patches or [ ] ++ lib.optionals config.services.mdevd.enable [ ./assets/pipewire/pipewire.patch ];
+      });
+
+  pipewire32' =
+    (pkgs.pkgsi686Linux.pipewire.override (
+      lib.optionalAttrs config.services.mdevd.enable {
+        enableSystemd = false;
+        udev = pkgs.libudev-zero;
+      }
+    )).overrideAttrs
+      (o: {
+        # https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2398#note_2967898
+        patches =
+          o.patches or [ ] ++ lib.optionals config.services.mdevd.enable [ ./assets/pipewire/pipewire.patch ];
+      });
+
+  # The package doesn't output to $out/lib/pipewire directly so that the
+  # overlays can use the outputs to replace the originals in FHS environments.
+  #
+  # This doesn't work in general because of missing development information.
+  jack-libs = pkgs.runCommand "jack-libs" { } ''
+    mkdir -p "$out/lib"
+    ln -s "${cfg.package.jack}/lib" "$out/lib/pipewire"
+  '';
+
+  configPackages = cfg.configPackages;
+
+  extraConfigPkg = extraConfigPkgFromFiles [ "pipewire" "client" "jack" "pipewire-pulse" ] (
+    mapToFiles "pipewire" cfg.extraConfig.pipewire
+    // mapToFiles "client" cfg.extraConfig.client
+    // mapToFiles "jack" cfg.extraConfig.jack
+    // mapToFiles "pipewire-pulse" cfg.extraConfig.pipewire-pulse
+  );
+
+  configs = pkgs.buildEnv {
+    name = "pipewire-configs";
+    paths =
+      configPackages
+      ++ [ extraConfigPkg ]
+      ++ optionals cfg.wireplumber.enable cfg.wireplumber.configPackages;
+    pathsToLink = [ "/share/pipewire" ];
+  };
+
+  requiredLv2Packages = flatten (
+    concatMap (p: attrByPath [ "passthru" "requiredLv2Packages" ] [ ] p) configPackages
+  );
+
+  lv2Plugins = pkgs.buildEnv {
+    name = "pipewire-lv2-plugins";
+    paths = cfg.extraLv2Packages ++ requiredLv2Packages;
+    pathsToLink = [ "/lib/lv2" ];
+  };
+
+  requiredLadspaPackages = flatten (
+    concatMap (p: attrByPath [ "passthru" "requiredLadspaPackages" ] [ ] p) configPackages
+  );
+
+  ladspaPlugins = pkgs.buildEnv {
+    name = "pipewire-ladspa-plugins";
+    paths = cfg.extraLadspaPackages ++ requiredLadspaPackages;
+    pathsToLink = [ "/lib/ladspa" ];
+  };
+
+in
+{
+  options.programs.pipewire = {
+    enable = mkEnableOption "A low-level server and multimedia framework for handling audio and video streams";
+
+    package = mkOption {
+      type = package;
+      default = pipewire';
+      defaultText = "pkgs.pipewire";
+      description = "The Pipewire package to use.";
+    };
+
+    alsa = {
+      enable = mkEnableOption "PipeWire-ALSA support";
+      support32Bit = mkEnableOption "32-bit ALSA support on 64-bit systems";
+    };
+
+    jack = {
+      enable = mkEnableOption "JACK audio emulation";
+    };
+
+    # TODO need networking.firewall to properly port over nixos/pipewire rapOpenFirewall option
+
+    extraConfig = {
+      pipewire = mkOption {
+        type = attrsOf json.type;
+        default = { };
+        example = {
+          "10-clock-rate" = {
+            "context.properties" = {
+              "default.clock.rate" = 44100;
+            };
+          };
+          "11-no-upmixing" = {
+            "stream.properties" = {
+              "channelmix.upmix" = false;
+            };
+          };
+        };
+        description = ''
+          Additional configuration for the PipeWire server.
+
+          Every item in this attrset becomes a separate drop-in file in `/etc/pipewire/pipewire.conf.d`.
+
+          See `man pipewire.conf` for details, and [the PipeWire wiki][wiki] for examples.
+
+          See also:
+          - [PipeWire wiki - virtual devices][wiki-virtual-device] for creating virtual devices or remapping channels
+          - [PipeWire wiki - filter-chain][wiki-filter-chain] for creating more complex processing pipelines
+          - [PipeWire wiki - network][wiki-network] for streaming audio over a network
+
+          [wiki]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Config-PipeWire
+          [wiki-virtual-device]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Virtual-Devices
+          [wiki-filter-chain]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Filter-Chain
+          [wiki-network]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Network
+        '';
+      };
+      client = mkOption {
+        type = attrsOf json.type;
+        default = { };
+        example = {
+          "10-no-resample" = {
+            "stream.properties" = {
+              "resample.disable" = true;
+            };
+          };
+        };
+        description = ''
+          Additional configuration for the PipeWire client library, used by most applications.
+
+          Every item in this attrset becomes a separate drop-in file in `/etc/pipewire/client.conf.d`.
+
+          See the [PipeWire wiki][wiki] for examples.
+
+          [wiki]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Config-client
+        '';
+      };
+      jack = mkOption {
+        type = attrsOf json.type;
+        default = { };
+        example = {
+          "20-hide-midi" = {
+            "jack.properties" = {
+              "jack.show-midi" = false;
+            };
+          };
+        };
+        description = ''
+          Additional configuration for the PipeWire JACK server and client library.
+
+          Every item in this attrset becomes a separate drop-in file in `/etc/pipewire/jack.conf.d`.
+
+          See the [PipeWire wiki][wiki] for examples.
+
+          [wiki]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Config-JACK
+        '';
+      };
+      pipewire-pulse = mkOption {
+        type = attrsOf json.type;
+        default = { };
+        example = {
+          "15-force-s16-info" = {
+            "pulse.rules" = [
+              {
+                matches = [
+                  { "application.process.binary" = "my-broken-app"; }
+                ];
+                actions = {
+                  quirks = [ "force-s16-info" ];
+                };
+              }
+            ];
+          };
+        };
+        description = ''
+          Additional configuration for the PipeWire PulseAudio server.
+
+          Every item in this attrset becomes a separate drop-in file in `/etc/pipewire/pipewire-pulse.conf.d`.
+
+          See `man pipewire-pulse.conf` for details, and [the PipeWire wiki][wiki] for examples.
+
+          See also:
+          - [PipeWire wiki - PulseAudio tricks guide][wiki-tricks] for more examples.
+
+          [wiki]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Config-PulseAudio
+          [wiki-tricks]: https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/Guide-PulseAudio-Tricks
+        '';
+      };
+    };
+
+    configPackages = mkOption {
+      type = listOf package;
+      default = [ ];
+      example = literalExpression ''
+        [
+                  (pkgs.writeTextDir "share/pipewire/pipewire.conf.d/10-loopback.conf" '''
+                    context.modules = [
+                    {   name = libpipewire-module-loopback
+                        args = {
+                          node.description = "Scarlett Focusrite Line 1"
+                          capture.props = {
+                              audio.position = [ FL ]
+                              stream.dont-remix = true
+                              node.target = "alsa_input.usb-Focusrite_Scarlett_Solo_USB_Y7ZD17C24495BC-00.analog-stereo"
+                              node.passive = true
+                          }
+                          playback.props = {
+                              node.name = "SF_mono_in_1"
+                              media.class = "Audio/Source"
+                              audio.position = [ MONO ]
+                          }
+                        }
+                    }
+                    ]
+                  ''')
+                ]'';
+      description = ''
+        List of packages that provide PipeWire configuration, in the form of
+        `share/pipewire/*/*.conf` files.
+
+        LV2/LADSPA dependencies will be picked up from config packages automatically
+        via `passthru.requiredLv2Packages`/`passthru.requiredLadspaPackages`.
+      '';
+    };
+
+    extraLv2Packages = mkOption {
+      type = listOf package;
+      default = [ ];
+      example = literalExpression "[ pkgs.lsp-plugins ]";
+      description = ''
+        List of packages that provide LV2 plugins in `lib/lv2` that should
+        be made available to PipeWire for [filter chains][wiki-filter-chain].
+
+        Config packages have their required LV2 plugins added automatically,
+        so they don't need to be specified here. Config packages need to set
+        `passthru.requiredLv2Packages` for this to work.
+
+        [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
+      '';
+    };
+
+    extraLadspaPackages = mkOption {
+      type = listOf package;
+      default = [ ];
+      example = literalExpression "[ pkgs.noisetorch-ladspa ]";
+      description = ''
+        List of packages that provide LADSPA plugins in `lib/ladspa` that should
+        be made available to PipeWire for [filter chains][wiki-filter-chain].
+
+        Config packages have their required LADSPA plugins added automatically,
+        so they don't need to be specified here. Config packages need to set
+        `passthru.requiredLadspaPackages` for this to work.
+
+        [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ] ++ optional cfg.jack.enable jack-libs;
+    environment.etc."security/limits.conf".text = ''
+      @audio   -   rtprio     95
+      @audio   -   nice       -19
+      @audio   -   memlock    4194304
+    '';
+    services.udev.packages = mkIf config.services.udev.enable [ cfg.package ];
+    services.mdevd.hotplugRules = mkIf (config.services.mdevd.enable && cfg.alsa.enable) (
+      lib.mkMerge [
+        (lib.mkAfter ''
+          SUBSYSTEM=input;.* root:input 660
+          SUBSYSTEM=sound;.* root:audio 660
+        '')
+
+        ''
+          # alsa sound devices and audio stuff
+          pcm.*       root:audio 0660 =snd/
+          control.*   root:audio 0660 =snd/
+          midi.*      root:audio 0660 =snd/
+          seq         root:audio 0660 =snd/
+          timer       root:audio 0660 =snd/
+
+          adsp        root:audio 0660 >sound/
+          audio       root:audio 0660 >sound/
+          dsp         root:audio 0660 >sound/
+          mixer       root:audio 0660 >sound/
+          sequencer.* root:audio 0660 >sound/
+        ''
+      ]
+    );
+
+    environment.etc = {
+      "alsa/conf.d/49-pipewire-modules.conf" = mkIf cfg.alsa.enable {
+        text = ''
+          pcm_type.pipewire {
+            libs.native = ${cfg.package}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;
+            ${optionalString enable32BitAlsaPlugins "libs.32Bit = ${pipewire32'}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;"}
+          }
+          ctl_type.pipewire {
+            libs.native = ${cfg.package}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;
+            ${optionalString enable32BitAlsaPlugins "libs.32Bit = ${pipewire32'}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;"}
+          }
+        '';
+      };
+
+      "alsa/conf.d/50-pipewire.conf" = mkIf cfg.alsa.enable {
+        source = "${cfg.package}/share/alsa/alsa.conf.d/50-pipewire.conf";
+      };
+
+      "alsa/conf.d/99-pipewire-default.conf" = mkIf cfg.alsa.enable {
+        source = "${cfg.package}/share/alsa/alsa.conf.d/99-pipewire-default.conf";
+      };
+      pipewire.source = "${configs}/share/pipewire";
+    };
+
+    security.pam.environment = {
+      LD_LIBRARY_PATH.default = mkif cfg.jack.enable [ "${cfg.package.jack}/lib" ];
+      LV2_PATH.default = "${lv2Plugins}/lib/lv2";
+      LADSPA_PATH.default = "${ladspaPlugins}/lib/ladspa";
+    };
+  };
+}

--- a/modules/programs/pipewire/pipewire.nix
+++ b/modules/programs/pipewire/pipewire.nix
@@ -321,10 +321,6 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [
       cfg.package
-
-      # ??? see 378
-      ladspaPlugins
-      lv2Plugins
     ]
     ++ optional cfg.jack.enable jack-libs;
 

--- a/modules/programs/pipewire/pipewire.nix
+++ b/modules/programs/pipewire/pipewire.nix
@@ -59,8 +59,7 @@ let
     )).overrideAttrs
       (o: {
         # https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2398#note_2967898
-        patches =
-          o.patches or [ ] ++ lib.optionals config.services.mdevd.enable [ ./assets/pipewire/pipewire.patch ];
+        patches = o.patches or [ ] ++ lib.optionals config.services.mdevd.enable [ ./pipewire.patch ];
       });
 
   pipewire32' =
@@ -71,9 +70,7 @@ let
       }
     )).overrideAttrs
       (o: {
-        # https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2398#note_2967898
-        patches =
-          o.patches or [ ] ++ lib.optionals config.services.mdevd.enable [ ./assets/pipewire/pipewire.patch ];
+        patches = o.patches or [ ] ++ lib.optionals config.services.mdevd.enable [ ./pipewire.patch ];
       });
 
   # The package doesn't output to $out/lib/pipewire directly so that the
@@ -320,38 +317,40 @@ in
       '';
     };
   };
+
   config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ] ++ optional cfg.jack.enable jack-libs;
+    environment.systemPackages = [
+      cfg.package
+
+      # ??? see 378
+      ladspaPlugins
+      lv2Plugins
+    ]
+    ++ optional cfg.jack.enable jack-libs;
+
+    services.udev.packages = mkIf config.services.udev.enable [ cfg.package ];
+    services.mdevd.hotplugRules = mkIf (config.services.mdevd.enable && cfg.alsa.enable) (
+      lib.mkAfter ''
+        # alsa sound devices and audio stuff
+        pcm.*       root:audio 0660 =snd/
+        control.*   root:audio 0660 =snd/
+        midi.*      root:audio 0660 =snd/
+        seq         root:audio 0660 =snd/
+        timer       root:audio 0660 =snd/
+
+        adsp        root:audio 0660 >sound/
+        audio       root:audio 0660 >sound/
+        dsp         root:audio 0660 >sound/
+        mixer       root:audio 0660 >sound/
+        sequencer.* root:audio 0660 >sound/
+      ''
+    );
+
     environment.etc."security/limits.conf".text = ''
       @audio   -   rtprio     95
       @audio   -   nice       -19
       @audio   -   memlock    4194304
     '';
-    services.udev.packages = mkIf config.services.udev.enable [ cfg.package ];
-    services.mdevd.hotplugRules = mkIf (config.services.mdevd.enable && cfg.alsa.enable) (
-      lib.mkMerge [
-        (lib.mkAfter ''
-          SUBSYSTEM=input;.* root:input 660
-          SUBSYSTEM=sound;.* root:audio 660
-        '')
-
-        ''
-          # alsa sound devices and audio stuff
-          pcm.*       root:audio 0660 =snd/
-          control.*   root:audio 0660 =snd/
-          midi.*      root:audio 0660 =snd/
-          seq         root:audio 0660 =snd/
-          timer       root:audio 0660 =snd/
-
-          adsp        root:audio 0660 >sound/
-          audio       root:audio 0660 >sound/
-          dsp         root:audio 0660 >sound/
-          mixer       root:audio 0660 >sound/
-          sequencer.* root:audio 0660 >sound/
-        ''
-      ]
-    );
-
     environment.etc = {
       "alsa/conf.d/49-pipewire-modules.conf" = mkIf cfg.alsa.enable {
         text = ''
@@ -376,10 +375,18 @@ in
       pipewire.source = "${configs}/share/pipewire";
     };
 
-    security.pam.environment = {
-      LD_LIBRARY_PATH.default = mkif cfg.jack.enable [ "${cfg.package.jack}/lib" ];
-      LV2_PATH.default = "${lv2Plugins}/lib/lv2";
-      LADSPA_PATH.default = "${ladspaPlugins}/lib/ladspa";
-    };
+    /*
+      TODO wtf do i do here?? this isn't a service so it doesn't have an environment,
+      but you need this junk to let JACK run properly and make the system aware of
+      any LV2 / LADSPA plugins. BUUUTTT, if any other module for whatever reason
+      wants to overwrite these values then they are SOL unless they mkForce or mkDefault
+      it which is NOT ideal for what should be obvious reasons
+    */
+
+    # security.pam.environment = {
+    #   LD_LIBRARY_PATH.default = mkIf cfg.jack.enable [ "${cfg.package.jack}/lib" ];
+    #   LV2_PATH.default = "${lv2Plugins}/lib/lv2";
+    #   LADSPA_PATH.default = "${ladspaPlugins}/lib/ladspa";
+    # };
   };
 }

--- a/modules/programs/pipewire/pipewire.patch
+++ b/modules/programs/pipewire/pipewire.patch
@@ -1,0 +1,37 @@
+diff --git a/spa/plugins/alsa/alsa-udev.c b/spa/plugins/alsa/alsa-udev.c
+index 9420401f0..04b1228d6 100644
+--- a/spa/plugins/alsa/alsa-udev.c
++++ b/spa/plugins/alsa/alsa-udev.c
+@@ -164,9 +164,6 @@ static unsigned int get_card_nr(struct impl *this, struct udev_device *udev_devi
+ 	if ((str = udev_device_get_property_value(udev_device, "SOUND_CLASS")) && spa_streq(str, "modem"))
+ 		return SPA_ID_INVALID;
+
+-	if (udev_device_get_property_value(udev_device, "SOUND_INITIALIZED") == NULL)
+-		return SPA_ID_INVALID;
+-
+ 	if ((str = udev_device_get_property_value(udev_device, "DEVPATH")) == NULL)
+ 		return SPA_ID_INVALID;
+
+@@ -970,7 +967,7 @@ static int enum_cards(struct impl *this)
+
+ 	for (udev_devices = udev_enumerate_get_list_entry(enumerate); udev_devices;
+ 			udev_devices = udev_list_entry_get_next(udev_devices)) {
+-		struct udev_device *udev_device;
++		struct udev_device *udev_device, *pdev;
+
+ 		udev_device = udev_device_new_from_syspath(this->udev,
+ 		                                           udev_list_entry_get_name(udev_devices));
+@@ -979,6 +976,13 @@ static int enum_cards(struct impl *this)
+
+ 		process_udev_device(this, ACTION_CHANGE, udev_device);
+
++		pdev = udev_device_get_parent(udev_device);
++
++		if (pdev)
++			process_udev_device(this, ACTION_CHANGE, pdev);
++
++		/* no need to unref pdev as udev_device_unref will free the parent as well */
++
+ 		udev_device_unref(udev_device);
+ 	}
+ 	udev_enumerate_unref(enumerate);

--- a/modules/programs/pipewire/wireplumber.nix
+++ b/modules/programs/pipewire/wireplumber.nix
@@ -6,13 +6,10 @@
 }:
 
 let
-  inherit (builtins) concatMap;
-  inherit (lib) maintainers;
-  inherit (lib.attrsets) attrByPath mapAttrsToList;
-  inherit (lib.lists) flatten;
+  inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
-  inherit (lib.strings) concatStringsSep makeSearchPath;
+  inherit (lib.strings) concatStringsSep;
   inherit (lib.types)
     bool
     listOf
@@ -58,7 +55,6 @@ let
     ) scripts;
 in
 {
-  meta.maintainers = [ maintainers.k900 ];
 
   options = {
     programs.pipewire.wireplumber = {
@@ -245,6 +241,7 @@ in
   };
 
   config =
+    # TODO wtf do i do with this shit??
     let
       extraConfigPkg = pkgs.buildEnv {
         name = "wireplumber-extra-config";
@@ -269,42 +266,13 @@ in
         pathsToLink = [ "/share/wireplumber" ];
       };
 
-      requiredLv2Packages = flatten (
-        concatMap (p: attrByPath [ "passthru" "requiredLv2Packages" ] [ ] p) configPackages
-      );
-
-      lv2Plugins = pkgs.buildEnv {
-        name = "wireplumber-lv2-plugins";
-        paths = cfg.extraLv2Packages ++ requiredLv2Packages;
-        pathsToLink = [ "/lib/lv2" ];
-      };
-
-      requiredLadspaPackages = flatten (
-        concatMap (p: attrByPath [ "passthru" "requiredLadspaPackages" ] [ ] p) configPackages
-      );
-
-      ladspaPlugins = pkgs.buildEnv {
-        name = "pipewire-ladspa-plugins";
-        paths = cfg.extraLadspaPackages ++ requiredLadspaPackages;
-        pathsToLink = [ "/lib/ladspa" ];
-      };
-
-      pluginsEnv = {
-        XDG_DATA_DIRS = makeSearchPath "share" [
-          configs
-          cfg.package
-        ];
-        LV2_PATH = "${lv2Plugins}/lib/lv2";
-        LADSPA_PATH = "${ladspaPlugins}/lib/ladspa";
-      };
     in
     mkIf cfg.enable {
-      environment.systemPackages = [ cfg.package ];
+      environment.systemPackages = [
+        cfg.package
 
-      security.pam.environment = with pluginsEnv; {
-        XDG_DATA_DIRS.default = XDG_DATA_DIRS;
-        LV2_PATH.default = LV2_PATH;
-        LADSPA_PATH.default = LADSPA_PATH;
-      };
+        # ???
+        configs
+      ];
     };
 }

--- a/modules/programs/pipewire/wireplumber.nix
+++ b/modules/programs/pipewire/wireplumber.nix
@@ -9,7 +9,7 @@ let
   inherit (builtins) concatMap;
   inherit (lib) maintainers;
   inherit (lib.attrsets) attrByPath mapAttrsToList;
-  inherit (lib.lists) flatten optional;
+  inherit (lib.lists) flatten;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
   inherit (lib.strings) concatStringsSep makeSearchPath;

--- a/modules/programs/pipewire/wireplumber.nix
+++ b/modules/programs/pipewire/wireplumber.nix
@@ -9,7 +9,7 @@ let
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
-  inherit (lib.strings) concatStringsSep makeSearchPath;
+  inherit (lib.strings) concatStringsSep;
   inherit (lib.types)
     bool
     listOf
@@ -271,14 +271,14 @@ in
         cfg.package
       ];
 
-      # TODO https://github.com/finix-community/issues/83
+      # https://github.com/finix-community/issues/83
       security.pam.environment = {
-        XDG_DATA_DIRS.default = lib.mkBefore [
-          (makeSearchPath "share" [
+        XDG_DATA_DIRS.default = lib.mkBefore (
+          map (p: "${p}/share") [
             configs
             cfg.package
-          ])
-        ];
+          ]
+        );
       };
     };
 }

--- a/modules/programs/pipewire/wireplumber.nix
+++ b/modules/programs/pipewire/wireplumber.nix
@@ -1,0 +1,310 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (builtins) concatMap;
+  inherit (lib) maintainers;
+  inherit (lib.attrsets) attrByPath mapAttrsToList;
+  inherit (lib.lists) flatten optional;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) literalExpression mkOption;
+  inherit (lib.strings) concatStringsSep makeSearchPath;
+  inherit (lib.types)
+    bool
+    listOf
+    attrsOf
+    package
+    lines
+    ;
+  inherit (lib.path) subpath;
+
+  pwCfg = config.programs.pipewire;
+  cfg = pwCfg.wireplumber;
+
+  wireplumber' = pkgs.wireplumber.override (
+    lib.optionalAttrs config.services.mdevd.enable {
+      pipewire = pwCfg.package;
+    }
+  );
+
+  json = pkgs.formats.json { };
+
+  configSectionsToConfFile =
+    path: value:
+    pkgs.writeTextDir path (
+      concatStringsSep "\n" (
+        mapAttrsToList (section: content: "${section} = " + (builtins.toJSON content)) value
+      )
+    );
+
+  mapConfigToFiles =
+    config:
+    mapAttrsToList (
+      name: value: configSectionsToConfFile "share/wireplumber/wireplumber.conf.d/${name}.conf" value
+    ) config;
+
+  mapScriptsToFiles =
+    scripts:
+    mapAttrsToList (
+      relativePath: value:
+      pkgs.writeTextDir (subpath.join [
+        "share/wireplumber/scripts"
+        relativePath
+      ]) value
+    ) scripts;
+in
+{
+  meta.maintainers = [ maintainers.k900 ];
+
+  options = {
+    programs.pipewire.wireplumber = {
+      enable = mkOption {
+        type = bool;
+        default = pwCfg.enable;
+        defaultText = literalExpression "config.services.pipewire.enable";
+        description = "Whether to enable WirePlumber, a modular session / policy manager for PipeWire";
+      };
+
+      package = mkOption {
+        type = package;
+        default = wireplumber';
+        defaultText = literalExpression "pkgs.wireplumber";
+        description = "The WirePlumber derivation to use.";
+      };
+
+      extraConfig = mkOption {
+        # Two layer attrset is necessary before using JSON, because of the whole
+        # config file not being a JSON object, but a concatenation of JSON objects
+        # in sections.
+        type = attrsOf (attrsOf json.type);
+        default = { };
+        example = literalExpression ''
+          {
+            "log-level-debug" = {
+              "context.properties" = {
+                # Output Debug log messages as opposed to only the default level (Notice)
+                "log.level" = "D";
+              };
+            };
+            "wh-1000xm3-ldac-hq" = {
+              "monitor.bluez.rules" = [
+                {
+                  matches = [
+                    {
+                      # Match any bluetooth device with ids equal to that of a WH-1000XM3
+                      "device.name" = "~bluez_card.*";
+                      "device.product.id" = "0x0cd3";
+                      "device.vendor.id" = "usb:054c";
+                    }
+                  ];
+                  actions = {
+                    update-props = {
+                      # Set quality to high quality instead of the default of auto
+                      "bluez5.a2dp.ldac.quality" = "hq";
+                    };
+                  };
+                }
+              ];
+            };
+          }
+        '';
+        description = ''
+          Additional configuration for the WirePlumber daemon when run in
+          single-instance mode (the default in nixpkgs and currently the only
+          supported way to run WirePlumber configured via `extraConfig`).
+
+          See also:
+          - [The configuration file][docs-the-conf-file]
+          - [Modifying configuration][docs-modifying-config]
+          - [Locations of files][docs-file-locations]
+          - and the [configuration section][docs-config-section] of the docs in general
+
+          Note that WirePlumber (and PipeWire) use dotted attribute names like
+          `device.product.id`. These are not nested, but flat objects for WirePlumber/PipeWire,
+          so to write these in nix expressions, remember to quote them like `"device.product.id"`.
+          Have a look at the example for this.
+
+          [docs-the-conf-file]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/conf_file.html
+          [docs-modifying-config]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/modifying_configuration.html
+          [docs-file-locations]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/locations.html
+          [docs-config-section]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration.html
+        '';
+      };
+
+      extraScripts = mkOption {
+        type = attrsOf lines;
+        default = { };
+        example = {
+          "test/hello-world.lua" = ''
+            print("Hello, world!")
+          '';
+        };
+        description = ''
+          Additional scripts for WirePlumber to be used by configuration files.
+
+          Every item in this attrset becomes a separate lua file with the path
+          relative to the `scripts` directory specified in the name of the item.
+          The scripts get passed to the WirePlumber service via the `XDG_DATA_DIRS`
+          variable. Scripts specified here are preferred over those shipped with
+          WirePlumber if they occupy the same relative path.
+
+          For a script to be loaded, it needs to be specified as part of a component,
+          and that component needs to be required by an active profile (e.g. `main`).
+          Components can be defined in config files either via `extraConfig` or `configPackages`.
+
+          For the hello-world example, you'd have to add the following `extraConfig`:
+          ```nix
+            services.pipewire.wireplumber.extraConfig."99-hello-world" = {
+              "wireplumber.components" = [
+                {
+                  name = "test/hello-world.lua";
+                  type = "script/lua";
+                  provides = "custom.hello-world";
+                }
+              ];
+
+              "wireplumber.profiles" = {
+                main = {
+                  "custom.hello-world" = "required";
+                };
+              };
+            };
+          ```
+
+          See also:
+          - [Location of scripts][docs-file-locations-scripts]
+          - [Components & Profiles][docs-components-profiles]
+          - [Migration - Loading custom scripts][docs-migration-loading-custom-scripts]
+
+          [docs-file-locations-scripts]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/locations.html#location-of-scripts
+          [docs-components-profiles]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/components_and_profiles.html
+          [docs-migration-loading-custom-scripts]: https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/migration.html#loading-custom-scripts
+        '';
+      };
+
+      configPackages = mkOption {
+        type = listOf package;
+        default = [ ];
+        example = literalExpression ''
+          [
+            (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/10-bluez.conf" '''
+              monitor.bluez.properties = {
+                bluez5.roles = [ a2dp_sink a2dp_source bap_sink bap_source hsp_hs hsp_ag hfp_hf hfp_ag ]
+                bluez5.codecs = [ sbc sbc_xq aac ]
+                bluez5.enable-sbc-xq = true
+                bluez5.hfphsp-backend = "native"
+              }
+            ''')
+          ]
+        '';
+        description = ''
+          List of packages that provide WirePlumber configuration, in the form of
+          `share/wireplumber/*/*.conf` files.
+
+          LV2/LADSPA dependencies will be picked up from config packages automatically
+          via `passthru.requiredLv2Packages`/`passthru.requiredLadspaPackages`.
+        '';
+      };
+
+      extraLv2Packages = mkOption {
+        type = listOf package;
+        default = [ ];
+        example = literalExpression "[ pkgs.lsp-plugins ]";
+        description = ''
+          List of packages that provide LV2 plugins in `lib/lv2` that should
+          be made available to WirePlumber for [filter chains][wiki-filter-chain].
+
+          Config packages have their required LV2 plugins added automatically,
+          so they don't need to be specified here. Config packages need to set
+          `passthru.requiredLv2Packages` for this to work.
+
+          [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
+        '';
+      };
+
+      extraLadspaPackages = mkOption {
+        type = listOf package;
+        default = [ ];
+        example = literalExpression "[ pkgs.noisetorch-ladspa ]";
+        description = ''
+          List of packages that provide LADSPA plugins in `lib/ladspa` that should
+          be made available to WirePlumber for [filter chains][wiki-filter-chain].
+
+          Config packages have their required LADSPA plugins added automatically,
+          so they don't need to be specified here. Config packages need to set
+          `passthru.requiredLadspaPackages` for this to work.
+
+          [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      extraConfigPkg = pkgs.buildEnv {
+        name = "wireplumber-extra-config";
+        paths = mapConfigToFiles cfg.extraConfig;
+        pathsToLink = [ "/share/wireplumber/wireplumber.conf.d" ];
+      };
+
+      extraScriptsPkg = pkgs.buildEnv {
+        name = "wireplumber-extra-scrips";
+        paths = mapScriptsToFiles cfg.extraScripts;
+        pathsToLink = [ "/share/wireplumber/scripts" ];
+      };
+
+      configPackages = cfg.configPackages ++ [
+        extraConfigPkg
+        extraScriptsPkg
+      ];
+
+      configs = pkgs.buildEnv {
+        name = "wireplumber-configs";
+        paths = configPackages;
+        pathsToLink = [ "/share/wireplumber" ];
+      };
+
+      requiredLv2Packages = flatten (
+        concatMap (p: attrByPath [ "passthru" "requiredLv2Packages" ] [ ] p) configPackages
+      );
+
+      lv2Plugins = pkgs.buildEnv {
+        name = "wireplumber-lv2-plugins";
+        paths = cfg.extraLv2Packages ++ requiredLv2Packages;
+        pathsToLink = [ "/lib/lv2" ];
+      };
+
+      requiredLadspaPackages = flatten (
+        concatMap (p: attrByPath [ "passthru" "requiredLadspaPackages" ] [ ] p) configPackages
+      );
+
+      ladspaPlugins = pkgs.buildEnv {
+        name = "pipewire-ladspa-plugins";
+        paths = cfg.extraLadspaPackages ++ requiredLadspaPackages;
+        pathsToLink = [ "/lib/ladspa" ];
+      };
+
+      pluginsEnv = {
+        XDG_DATA_DIRS = makeSearchPath "share" [
+          configs
+          cfg.package
+        ];
+        LV2_PATH = "${lv2Plugins}/lib/lv2";
+        LADSPA_PATH = "${ladspaPlugins}/lib/ladspa";
+      };
+    in
+    mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+
+      security.pam.environment = with pluginsEnv; {
+        XDG_DATA_DIRS.default = XDG_DATA_DIRS;
+        LV2_PATH.default = LV2_PATH;
+        LADSPA_PATH.default = LADSPA_PATH;
+      };
+    };
+}

--- a/modules/programs/pipewire/wireplumber.nix
+++ b/modules/programs/pipewire/wireplumber.nix
@@ -271,6 +271,7 @@ in
         cfg.package
       ];
 
+      # TODO https://github.com/finix-community/issues/83
       security.pam.environment = {
         XDG_DATA_DIRS.default = lib.mkBefore [
           (makeSearchPath "share" [

--- a/modules/programs/pipewire/wireplumber.nix
+++ b/modules/programs/pipewire/wireplumber.nix
@@ -9,7 +9,7 @@ let
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
-  inherit (lib.strings) concatStringsSep;
+  inherit (lib.strings) concatStringsSep makeSearchPath;
   inherit (lib.types)
     bool
     listOf
@@ -241,7 +241,6 @@ in
   };
 
   config =
-    # TODO wtf do i do with this shit??
     let
       extraConfigPkg = pkgs.buildEnv {
         name = "wireplumber-extra-config";
@@ -270,9 +269,15 @@ in
     mkIf cfg.enable {
       environment.systemPackages = [
         cfg.package
-
-        # ???
-        configs
       ];
+
+      security.pam.environment = {
+        XDG_DATA_DIRS.default = lib.mkBefore [
+          (makeSearchPath "share" [
+            configs
+            cfg.package
+          ])
+        ];
+      };
     };
 }


### PR DESCRIPTION
set up as a program with all the extra configuration options present in nixos. builds and runs. i have no idea what to do about the config options using pkgs.buildEnv or pipewire upstream setting up environment variables. wireplumber upstream also wants to add onto XDG_DATA_DIRS as that is where wireplumber looks for extra configuration scripts. 

opening as draft for now until we get more consensus on if to even include this as a core program module in the first place.