### PR TITLE
modules/limine: fixes

### DIFF
--- a/modules/programs/limine/default.nix
+++ b/modules/programs/limine/default.nix
@@ -133,7 +133,7 @@ in
       };
       default = { };
       description = ''
-        `limine` configuration. See [upstream documentation](https://codeberg.org/Limine/Limine/src/branch/v${lib.versions.major cfg.package.version}.x/CONFIG.md)
+        `limine` configuration. See [upstream documentation](https://github.com/Limine-Bootloader/Limine/blob/v${lib.versions.major cfg.package.version}.x/CONFIG.md)
         for additional details.
       '';
     };
@@ -159,7 +159,7 @@ in
           path: boot():///efi/memtest86/memtest86.efi
       '';
       description = ''
-        A string which is appended to the end of limine.conf. The config format can be found [here](https://codeberg.org/Limine/Limine/src/branch/v${lib.versions.major cfg.package.version}.x/CONFIG.md).
+        A string which is appended to the end of limine.conf. The config format can be found [here](https://github.com/Limine-Bootloader/Limine/blob/v${lib.versions.major cfg.package.version}.x/CONFIG.md).
       '';
     };
 

--- a/modules/programs/limine/limine-install.py
+++ b/modules/programs/limine/limine-install.py
@@ -442,7 +442,7 @@ def install_bootloader() -> None:
       elif type(value) is list:
         if key == 'wallpaper':
           for elem in value:
-            config_file += f'''key: {get_copied_path_uri(elem, 'wallpapers')}\n'''
+            config_file += f'''{key}: {get_copied_path_uri(elem, 'wallpapers')}\n'''
         else:
           for elem in value:
             config_file += f'{key}: {elem}\n'


### PR DESCRIPTION
1. Fixes the documentation links being dead for the `limine` module
2. More importantly, fixes the wallpapers not being entered into the config right. an honest mistake :)