### PR TITLE
modules/coreutils: init

### DIFF
--- a/modules/boot/default.nix
+++ b/modules/boot/default.nix
@@ -18,9 +18,9 @@
       runlevels = "S";
       command = pkgs.writeShellApplication {
         name = "remount-nix-store.sh";
-        runtimeInputs = with pkgs; [
-          coreutils
-          util-linux
+        runtimeInputs = [
+          config.programs.coreutils.package
+          pkgs.util-linux
         ];
         text = ''
           #!${pkgs.runtimeShell}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -4,6 +4,7 @@ let
       "README.md"
 
       # required modules - included by default
+      "coreutils"
       "plymouth"
       "resolvconf"
       "shadow"
@@ -44,6 +45,7 @@ in
       ./networking
       ./nixos
       ./nixpkgs
+      ./programs/coreutils
       ./programs/plymouth
       ./programs/resolvconf
       ./programs/shadow

--- a/modules/environment/etc/default.nix
+++ b/modules/environment/etc/default.nix
@@ -205,7 +205,7 @@ in
       mkdir -p -m 0755 /usr/bin /bin
 
       # Create /usr/bin/env for shebangs.
-      ln -sfn ${pkgs.coreutils}/bin/env /usr/bin/env
+      ln -sfn ${lib.getExe' config.programs.coreutils.package "env"} /usr/bin/env
 
       # Create the required /bin/sh symlink; otherwise lots of things
       # (notably the system() function) won't work.

--- a/modules/environment/path/default.nix
+++ b/modules/environment/path/default.nix
@@ -56,7 +56,6 @@
       zstd
 
       bashInteractive
-      coreutils-full
       gawk
       gnugrep
       gnupatch

--- a/modules/environment/shells/default.nix
+++ b/modules/environment/shells/default.nix
@@ -45,7 +45,7 @@ in
 
         eval "$(${pkgs.coreutils}/bin/dircolors -b)"
 
-        alias -- ls='ls --color=tty'
+        alias -- ls='ls --color=auto'
       fi
     '';
   };

--- a/modules/finit/default.nix
+++ b/modules/finit/default.nix
@@ -892,7 +892,7 @@ in
 
     # TODO: decide a reasonable default here... user can override if needed
     finit.path = [
-      pkgs.coreutils
+      config.programs.coreutils.package
       pkgs.findutils
       pkgs.gnugrep
       pkgs.gnused

--- a/modules/programs/coreutils/default.nix
+++ b/modules/programs/coreutils/default.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  options.programs.coreutils.package = lib.mkOption {
+    type = lib.types.package;
+    default = pkgs.coreutils;
+    defaultText = lib.literalExpression "pkgs.coreutils";
+    example = lib.literalExpression "pkgs.busybox";
+    description = ''
+      Package providing the standard core utilities used by the system.
+
+      Most modules should use this option instead of depending directly on
+      `pkgs.coreutils`, allowing alternative implementations such as 
+      `uutils`, `busybox`, or `toybox` to be selected globally.
+    '';
+  };
+
+  config.environment.systemPackages = [ config.programs.coreutils.package ];
+}

--- a/modules/programs/regreet/default.nix
+++ b/modules/programs/regreet/default.nix
@@ -160,7 +160,7 @@ in
         // lib.optionalAttrs config.services.xserver.enable or false {
           x11_prefix = [
             (lib.getExe' xinit' "startx")
-            (lib.getExe' pkgs.coreutils "env")
+            (lib.getExe' config.programs.coreutils.package "env")
           ];
         };
     };

--- a/modules/programs/tuigreet/default.nix
+++ b/modules/programs/tuigreet/default.nix
@@ -74,7 +74,7 @@ in
       ]
       ++ lib.optionals config.services.xserver.enable or false [
         "--xsession-wrapper"
-        "${lib.getExe' xinit' "startx"} ${lib.getExe' pkgs.coreutils "env"}"
+        "${lib.getExe' xinit' "startx"} ${lib.getExe' config.programs.coreutils.package "env"}"
       ];
 
     services.greetd.enable = true;

--- a/modules/security/wrappers/default.nix
+++ b/modules/security/wrappers/default.nix
@@ -179,7 +179,7 @@ let
     chmod 755 "${parentWrapperDir}"
 
     # We want to place the tmpdirs for the wrappers to the parent dir.
-    wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
+    wrapperDir=$(mktemp -d -p "${parentWrapperDir}" wrappers.XXXXXXXXXX)
     chmod a+rx "$wrapperDir"
 
     ${lib.concatStringsSep "\n" mkWrappedPrograms}
@@ -189,14 +189,14 @@ let
       # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
       old=$(readlink -f ${wrapperDir})
       if [ -e "${wrapperDir}-tmp" ]; then
-        rm --force --recursive "${wrapperDir}-tmp"
+        rm -rf "${wrapperDir}-tmp"
       fi
-      ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
-      mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
-      rm --force --recursive "$old"
+      ln -sfn "$wrapperDir" "${wrapperDir}-tmp"
+      mv -T "${wrapperDir}-tmp" "${wrapperDir}"
+      rm -rf "$old"
     else
       # For initial setup
-      ln --symbolic "$wrapperDir" "${wrapperDir}"
+      ln -s "$wrapperDir" "${wrapperDir}"
     fi
   '';
 

--- a/modules/security/wrappers/default.nix
+++ b/modules/security/wrappers/default.nix
@@ -274,7 +274,7 @@ in
       runlevels = "S12345";
       log = true;
       command = wrappersScript;
-      path = [ pkgs.coreutils ];
+      path = [ config.programs.coreutils.package ];
     };
   };
 }

--- a/modules/services/cron/default.nix
+++ b/modules/services/cron/default.nix
@@ -64,7 +64,7 @@ in
             defaultText = lib.literalExpression ''
               [
                 ${builtins.dirOf config.security.wrapperDir}
-                pkgs.coreutils
+                config.programs.coreutils.package
               ]
             '';
             description = ''
@@ -174,7 +174,7 @@ in
     services.cron.settings = {
       PATH = [
         (builtins.dirOf config.security.wrapperDir)
-        pkgs.coreutils
+        config.programs.coreutils.package
       ];
     };
 

--- a/modules/services/incus/default.nix
+++ b/modules/services/incus/default.nix
@@ -59,7 +59,7 @@ in
           bash
           btrfs-progs
           cdrkit
-          coreutils
+          config.programs.coreutils.package
           criu
           dnsmasq
           e2fsprogs

--- a/modules/services/mariadb/default.nix
+++ b/modules/services/mariadb/default.nix
@@ -122,10 +122,10 @@ in
 
       command = pkgs.writeShellApplication {
         name = "mariadb-init.sh";
-        runtimeInputs = with pkgs; [
-          coreutils
-          nettools
-          gnused
+        runtimeInputs = [
+          config.programs.coreutils.package
+          pkgs.nettools
+          pkgs.gnused
         ];
         text = ''
           if ! test -e '${cfg.dataDir}/mysql'; then

--- a/modules/services/mdevd/default.nix
+++ b/modules/services/mdevd/default.nix
@@ -197,11 +197,11 @@ in
       log = true;
 
       # TODO: now we're hijacking `env` and no one else can use it...
-      path = with pkgs; [
-        coreutils
-        execline
-        kmod
-        util-linux
+      path = [
+        config.programs.coreutils.package
+        pkgs.execline
+        pkgs.kmod
+        pkgs.util-linux
       ];
     };
 

--- a/modules/services/nzbget/default.nix
+++ b/modules/services/nzbget/default.nix
@@ -145,7 +145,7 @@ in
 
         pre = pkgs.writeShellScript "nzbget-pre.sh" ''
           if [ ! -f ${configFile} ]; then
-            ${pkgs.coreutils}/bin/install -o ${cfg.user} -g ${cfg.group} -m 0700 ${cfg.package}/share/nzbget/nzbget.conf ${configFile}
+            ${lib.getExe' config.programs.coreutils "install"} -o ${cfg.user} -g ${cfg.group} -m 0700 ${cfg.package}/share/nzbget/nzbget.conf ${configFile}
           fi
         '';
       };

--- a/modules/services/php-fpm/default.nix
+++ b/modules/services/php-fpm/default.nix
@@ -135,7 +135,7 @@ in
     finit.services.php-fpm = {
       conditions = "service/syslogd/ready";
       command = "${cfg.package}/bin/php-fpm -y ${configFile}";
-      reload = "${pkgs.coreutils}/bin/kill -USR2 $MAINPID";
+      reload = "${lib.getExe' config.programs.coreutils.package "kill"} -USR2 $MAINPID";
       notify = "systemd";
     };
 

--- a/modules/services/rsyslog/default.nix
+++ b/modules/services/rsyslog/default.nix
@@ -77,7 +77,7 @@ in
           sharedscripts
 
           postrotate
-            ${pkgs.coreutils}/bin/kill -s HUP $(cat /run/rsyslog.pid)
+            ${lib.getExe' config.programs.coreutils.package "kill"} -s HUP $(cat /run/rsyslog.pid)
           endscript
         }
       '';

--- a/modules/services/udev/default.nix
+++ b/modules/services/udev/default.nix
@@ -58,9 +58,9 @@ let
             --replace-quiet \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
             --replace-quiet \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
             --replace-quiet \"/bin/mount \"${pkgs.util-linux}/bin/mount \
-            --replace-quiet /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
-            --replace-quiet /usr/bin/cat ${pkgs.coreutils}/bin/cat \
-            --replace-quiet /usr/bin/basename ${pkgs.coreutils}/bin/basename 2>/dev/null
+            --replace-quiet /usr/bin/readlink ${lib.getExe' config.programs.coreutils.package "readline"} \
+            --replace-quiet /usr/bin/cat ${lib.getExe' config.programs.coreutils.package "cat"}/bin/cat \
+            --replace-quiet /usr/bin/basename ${lib.getExe' config.programs.coreutils.package "basename"}/bin/basename 2>/dev/null
         done
 
         echo -n "Checking that all programs called by relative paths in udev rules exist in ${udev}/lib/udev... "
@@ -223,7 +223,7 @@ in
   config = lib.mkIf cfg.enable {
     # services.udev.packages = [ extraUdevRules extraHwdbFile ];
     services.udev.path = [
-      pkgs.coreutils
+      config.programs.coreutils.package
       pkgs.gnused
       pkgs.gnugrep
       pkgs.util-linux

--- a/modules/system/activation/default.nix
+++ b/modules/system/activation/default.nix
@@ -142,18 +142,16 @@ in
       "L+ /var/run - - - - /run"
     ];
 
-    system.activation.path =
-      with pkgs;
-      map lib.getBin [
-        coreutils
-        gnugrep
-        findutils
-        getent
-        stdenv.cc.libc # nscd in update-users-groups.pl
-        shadow
-        nettools # needed for hostname
-        util-linux # needed for mount and mountpoint
-      ];
+    system.activation.path = map lib.getBin [
+      config.programs.coreutils.package
+      pkgs.gnugrep
+      pkgs.findutils
+      pkgs.getent
+      pkgs.stdenv.cc.libc # nscd in update-users-groups.pl
+      pkgs.shadow
+      pkgs.nettools # needed for hostname
+      pkgs.util-linux # needed for mount and mountpoint
+    ];
 
     system.topLevel = checkAssertWarn (
       pkgs.stdenvNoCC.mkDerivation {
@@ -198,7 +196,7 @@ in
               --subst-var-by distroId finix \
               --subst-var-by finit ${config.finit.package} \
               --subst-var-by logger ${pkgs.util-linuxMinimal} \
-              --subst-var-by coreutils ${pkgs.coreutils} \
+              --subst-var-by coreutils ${config.programs.coreutils.package} \
               --subst-var-by installHook ${config.providers.bootloader.installHook}
           ''
           + lib.optionalString config.boot.bootspec.enable ''


### PR DESCRIPTION
> Package providing the standard core utilities used by the system.
> Most modules should use this option instead of depending directly on
> `pkgs.coreutils`, allowing alternative implementations such as 
> `uutils`, `busybox`, or `toybox` to be selected globally.