### PR TITLE
modules/environment: made /bin/sh's symlink an easily modifiable variable

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   finix-logo = pkgs.runCommand "finix-logo" { } ''
     install -Dm644 ${../../assets/finix-logo.svg} $out/share/icons/hicolor/scalable/apps/finix-logo.svg
@@ -10,6 +10,17 @@ in
     ./path
     ./shells
   ];
+
+  options.environment.binsh = lib.mkOption {
+    type = lib.types.path;
+    default = "${pkgs.bashInteractive}/bin/sh";
+    defaultText = lib.literalExpression ''"''${pkgs.bashInteractive}/bin/sh"'';
+    example = lib.literalExpression ''"''${pkgs.dash}/bin/dash"'';
+    description = ''
+      Default shell linked system-wide to `/bin/sh`. Do your best to make sure any
+      modifications to this shell are POSIX-compliant.
+    '';
+  };
 
   config = {
     environment.systemPackages = [ finix-logo ];

--- a/modules/environment/etc/default.nix
+++ b/modules/environment/etc/default.nix
@@ -209,7 +209,7 @@ in
 
       # Create the required /bin/sh symlink; otherwise lots of things
       # (notably the system() function) won't work.
-      ln -sfn "${pkgs.bashInteractive}/bin/sh" /bin/sh
+      ln -sfn "${config.environment.binsh}" /bin/sh
     '';
   };
 }


### PR DESCRIPTION
Added a straight forward option to set the executable linked to be `/bin/sh` system-wide.