### PR TITLE
services/nix-daemon: create per-user nix profile and gcroots dirs

### DIFF
--- a/modules/services/nix-daemon/default.nix
+++ b/modules/services/nix-daemon/default.nix
@@ -308,7 +308,16 @@ in
       # Prevent the current configuration from being garbage-collected.
       "d /nix/var/nix/gcroots -"
       "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"
-    ];
+
+      # Per-user profile and gcroots directories, required by nix-env and
+      # tools like home-manager that run nix operations as unprivileged users.
+      "d /nix/var/nix/profiles/per-user 1777 root root - -"
+      "d /nix/var/nix/gcroots/per-user  1777 root root - -"
+    ] ++ lib.mapAttrsToList (name: _: "d /nix/var/nix/profiles/per-user/${name} 0755 ${name} root - -") (
+      lib.filterAttrs (name: u: !u.isSystemUser) config.users.users
+    ) ++ lib.mapAttrsToList (name: _: "d /nix/var/nix/gcroots/per-user/${name}  0755 ${name} root - -") (
+      lib.filterAttrs (name: u: !u.isSystemUser) config.users.users
+    );
 
     users.users = lib.listToAttrs (
       map (nr: {


### PR DESCRIPTION
Without these directories, tools like nix-env and home-manager that run nix operations as non-root users fail on first boot because neither /nix/var/nix/profiles/per-user/<user> nor ~/.local/state/nix/profiles exist yet, which home-manager's setupVars treats as a fatal error.

NixOS handles this via systemd tmpfiles; this is the finix equivalent.