### PR TITLE
modules/lxqt: drop /share from environment.pathsToLink

### DIFF
--- a/modules/programs/lxqt/default.nix
+++ b/modules/programs/lxqt/default.nix
@@ -212,7 +212,6 @@ in
       ];
 
     environment.pathsToLink = [
-      "/share"
       "/share/icons"
       "/share/pixmaps"
     ];


### PR DESCRIPTION
this is far too reaching - if additional entries under `/share/...` are needed they should be added explicitly

cc @deathbymanatee