### PR TITLE
add result-* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
+result-*
 .nixos-test-history


### PR DESCRIPTION
This is useful after running multiple tests using `nix-build ./tests`
