### PR TITLE
implement nixos inhibitors for generation switching

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -59,6 +59,7 @@ in
       ./services/udev
       ./system/activation
       ./system/activation/specialisation.nix
+      ./system/activation/switchable-system.nix
       ./system/nixos-compat.nix
       ./time
       ./users

--- a/modules/finit/switch-to-configuration.sh
+++ b/modules/finit/switch-to-configuration.sh
@@ -5,6 +5,7 @@ out="@out@"
 localeArchive="@localeArchive@"
 distroId="@distroId@"
 installHook="@installHook@"
+inhibitCheck="@inhibitCheck@"
 finit="@finit@"
 logger="@logger@"
 coreutils="@coreutils@"
@@ -46,6 +47,12 @@ fi
 # fi
 
 "$logger/bin/logger" -t finix "starting switch-to-configuration ($action)"
+
+if [[ "$action" != boot && "${NIXOS_NO_CHECK-}" != 1 ]]; then
+  if ! "$inhibitCheck" "$out"; then
+    exit 1
+  fi
+fi
 
 # install bootloader
 if [[ "$action" == switch || "$action" == boot ]]; then

--- a/modules/programs/sudo/default.nix
+++ b/modules/programs/sudo/default.nix
@@ -67,6 +67,9 @@ in
           # Keep terminfo database for root and %wheel.
           Defaults:root,%wheel env_keep+=TERMINFO_DIRS
           Defaults:root,%wheel env_keep+=TERMINFO
+
+          # keep NIXOS_NO_CHECK for `nixos-rebuild switch`
+          Defaults env_keep+=NIXOS_NO_CHECK
         '')
 
         ''

--- a/modules/system/activation/default.nix
+++ b/modules/system/activation/default.nix
@@ -173,6 +173,7 @@ in
 
             ${coreutils}/bin/ln -sr ${config.finit.package}/bin/finit $out/init
             ${coreutils}/bin/ln -s ${config.environment.path} $out/sw
+            ${coreutils}/bin/ln -s ${config.system.build.inhibitSwitch} $out/switch-inhibitors
 
             mkdir $out/specialisation
 
@@ -199,7 +200,8 @@ in
               --subst-var-by finit ${config.finit.package} \
               --subst-var-by logger ${pkgs.util-linuxMinimal} \
               --subst-var-by coreutils ${config.programs.coreutils.package} \
-              --subst-var-by installHook ${config.providers.bootloader.installHook}
+              --subst-var-by installHook ${config.providers.bootloader.installHook} \
+              --subst-var-by inhibitCheck ${config.system.build.checkSwitchInhibitors}
           ''
           + lib.optionalString config.boot.bootspec.enable ''
             ${config.boot.bootspec.writer}

--- a/modules/system/activation/switchable-system.nix
+++ b/modules/system/activation/switchable-system.nix
@@ -1,0 +1,87 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  empty = pkgs.writeText "no-inhibitors" "{}";
+
+  checkSwitchInhibitors = pkgs.writeShellApplication {
+    name = "check-switch-inhibitors";
+    runtimeInputs = [ pkgs.jq ];
+    text = ''
+      incoming="$1"
+
+      exec >&2
+
+      current_inhibitors="/run/current-system/switch-inhibitors"
+      if [ ! -f "$current_inhibitors" ]; then
+        current_inhibitors="${empty}"
+      fi
+
+      new_inhibitors="$incoming/switch-inhibitors"
+      if [ ! -f "$new_inhibitors" ]; then
+        new_inhibitors="${empty}"
+      fi
+
+      echo -n "checking switch inhibitors..."
+
+      diff="$(
+        jq \
+          --raw-output \
+          --null-input \
+          --rawfile current "$current_inhibitors" \
+          --rawfile newgen "$new_inhibitors" \
+        '
+          ($current | fromjson) as $old |
+          ($newgen | fromjson) as $new |
+          $old |
+          to_entries |
+          map(
+            select(.key | in ($new)) |
+            select(.value != $new.[.key]) |
+            [ .key, ":", .value, "->", $new.[.key] ] | join(" ")
+          ) |
+          join("\n")
+        ' \
+      )"
+
+      if [ -n "$diff" ]; then
+        echo
+        echo "there are changes to critical components of the system:"
+        echo
+        echo "$diff"
+        echo
+        echo "switching into this system is not recommended"
+        echo "you probably want to run 'nixos-rebuild boot' and reboot your system instead"
+        echo
+        echo "if you really want to switch into this configuration directly, then"
+        echo "you can set NIXOS_NO_CHECK=1 to ignore switch inhibitors"
+        echo
+        echo "WARNING: doing so might cause the switch to fail or your system to become unstable"
+        echo
+
+        exit 1
+      else
+        echo " done"
+      fi
+    '';
+  };
+in
+{
+  options.system.switch.inhibitors = lib.mkOption {
+    type = with lib.types; attrsOf str;
+    default = { };
+    description = ''
+      Attribute set of strings that will prevent switching into a configuration when
+      they change.
+      The switch can be manually forced on the command line if required.
+    '';
+  };
+
+  config = {
+    system.build.inhibitSwitch = pkgs.writers.writeJSON "switch-inhibitors" config.system.switch.inhibitors;
+    system.build.checkSwitchInhibitors = lib.getExe checkSwitchInhibitors;
+  };
+}


### PR DESCRIPTION
some newer functionality in `nixos` that could be very useful to `finix`!

one possible example is to prevent the `syslog` from being restarted during regular system operation via:

```
system.switch.inhibitors.syslogd = toString config.services.sysklogd.package;
```