### PR TITLE
modules/nixos-compat: make system.build use lazyAttrsOf

### DIFF
--- a/modules/system/nixos-compat.nix
+++ b/modules/system/nixos-compat.nix
@@ -11,7 +11,7 @@
     default = { };
 
     type = lib.types.submodule {
-      freeformType = lib.types.attrsOf lib.types.anything;
+      freeformType = lib.types.lazyAttrsOf lib.types.anything;
 
       options = {
         nixos-rebuild = lib.mkOption {


### PR DESCRIPTION
This change makes system.build use lazyAttrsOf like in upstream NixOS, using non-lazy version causes modules like disko to evaluate multiple times and break.

Example of error:

```
building the system configuration...
warning: Git tree '/etc/nixos' is dirty
evaluation warning: Subvolume /root-blank has mountOptions but no mountpoint. See upgrade guide (2023-07-09 121df48).
trace: the .disko output is deprecated, please use .diskoScript instead
evaluation warning: Subvolume /root-blank has mountOptions but no mountpoint. See upgrade guide (2023-07-09 121df48).
trace: the .disko output is deprecated, please use .diskoScript instead
...omitted...
       error: The option `disko.devices.disk.main.content.partitions.nixos-boot.content.mountpoint' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `<unknown-file>': "/boot"
       - In `<unknown-file>': "/boot"
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

In total it tries to evaluate disko options 3 times before failing on final merge to toplevel. 