### PR TITLE
programs/shadow: create dummy /etc/security/limits.conf file

### DIFF
--- a/modules/programs/shadow/default.nix
+++ b/modules/programs/shadow/default.nix
@@ -144,6 +144,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.etc."security/limits.conf".text = lib.mkDefault "";
     environment.etc."login.defs".source = format.generate "login.defs" cfg.settings;
 
     security.pam.services.login = {


### PR DESCRIPTION
Add dummy /etc/security/limits.conf file, otherwise pam complains about it and won't let any user login.

For example:
```
Jul  1 19:15:23 finix login[546]: pam_unix(login:session): session opened for user root(uid=0) by LOGIN(uid=0)
Jul  1 19:15:23 finix login[546]: pam_limits(login:session): cannot read settings from /etc/security/limits.conf: No such file or directory
Jul  1 19:15:23 finix login[546]: pam_limits(login:session): error parsing the configuration file: '/etc/security/limits.conf' 
Jul  1 19:15:23 finix login[546]: Error in service module
``` 