### PR TITLE
modules/virtualisation/qemu: fall back when   hostPlatform.linux-kernel is absent

### DIFF
--- a/modules/virtualisation/qemu.nix
+++ b/modules/virtualisation/qemu.nix
@@ -109,7 +109,7 @@ let
   bootModeArgs = {
     kernel = [
       "-kernel"
-      "${config.boot.kernelPackages.kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}"
+      "${config.boot.kernelPackages.kernel}/${config.boot.kernelPackages.kernel.target or pkgs.stdenv.hostPlatform.linux-kernel.target}"
       "-initrd"
       "${config.boot.initrd.package}/initrd"
       "-append"

--- a/modules/virtualisation/qemu.nix
+++ b/modules/virtualisation/qemu.nix
@@ -109,7 +109,9 @@ let
   bootModeArgs = {
     kernel = [
       "-kernel"
-      "${config.boot.kernelPackages.kernel}/${config.boot.kernelPackages.kernel.target or pkgs.stdenv.hostPlatform.linux-kernel.target}"
+      "${config.boot.kernelPackages.kernel}/${
+        config.boot.kernelPackages.kernel.target or config.boot.kernelPackages.stdenv.hostPlatform.linux-kernel.target
+      }"
       "-initrd"
       "${config.boot.initrd.package}/initrd"
       "-append"


### PR DESCRIPTION
Problem:
nixpkgs removed linux-kernel from platform elaboration during the 26.11 cycle (https://github.com/NixOS/nixpkgs/pull/530133). On any nixos-unstable from roughly mid-June onward, evaluating a VM built via tests/lib fails:
```
error:
       … while checking flake output 'packages'

       … while checking the derivation 'packages.x86_64-linux.vm-icarus'

       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating the option `virtualisation.qemu.argv':

       … while evaluating definitions from `/nix/store/5dbfplbzn8p42s9q1rsrrvjqn9pndi7i-source/modules/virtualisation/qemu.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'linux-kernel' missing
       at «github:finix-community/finix/6f527e0439a16d03e4f3889b1c2a6b35404d1004?narHash=sha256-RXvEgkVX69kQzT7sgF40VuALqMVk5degJzgWG/nOC9w%3D»/modules/virtualisation/qemu.nix:112:47:
          111|       "-kernel"
          112|       "${config.boot.kernelPackages.kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}"
             |                                               ^
          113|       "-initrd"
```
The Modules modules/boot/bootspec.nix and modules/system/activation/default.nix handle this already with the fallback:

config.boot.kernelPackages.kernel.target or pkgs.stdenv.hostPlatform.linux-kernel.target

qemu.nix:112 was the one remaining call site without it.