### PR TITLE
modules/services/udev: include eudev's bundled default rules

### DIFF
--- a/modules/services/udev/default.nix
+++ b/modules/services/udev/default.nix
@@ -282,8 +282,8 @@ in
     environment.etc."udev/hwdb.bin" = lib.mkIf (cfg.packages != [ ]) { source = hwdbBin; };
     environment.etc."udev/rules.d".source = udevRulesFor {
       name = "udev-rules";
-      udevPackages = cfg.packages;
-      binPackages = cfg.packages;
+      udevPackages = [ cfg.package ] ++ cfg.packages;
+      binPackages = [ cfg.package ] ++ cfg.packages;
       udev = cfg.package;
 
       inherit udevPath;


### PR DESCRIPTION
Issue: if udev is used without elogind it is missing crucial rules. This manifests as: no kernel module autoload for hotplugged devices, no /dev/disk/by-* symlinks after switch-root, missing default device permissions/tags.

Fix: include the default rules in the aggregation.

Build and tested on hardware