### PR TITLE
(fix) modules/services/networkmanager: set rc-manager explicitly

### DIFF
--- a/modules/services/networkmanager/default.nix
+++ b/modules/services/networkmanager/default.nix
@@ -43,6 +43,13 @@ in
     services.dbus.packages = packages;
     services.udev.packages = packages;
 
+    # nixpkgs builds NetworkManager with a hardcoded resolvconf path, so the
+    # default rc-manager=auto always selects resolvconf, even when nothing
+    # has set it up, silently dropping DNS updates.
+    environment.etc."NetworkManager/NetworkManager.conf".text = lib.generators.toINI { } {
+      main.rc-manager = if config.programs.resolvconf.enable then "resolvconf" else "symlink";
+    };
+
     finit.services.network-manager = {
       description = "network manager service";
       conditions = "service/dbus/ready";

--- a/modules/services/networkmanager/default.nix
+++ b/modules/services/networkmanager/default.nix
@@ -46,7 +46,7 @@ in
     # nixpkgs builds NetworkManager with a hardcoded resolvconf path, so the
     # default rc-manager=auto always selects resolvconf, even when nothing
     # has set it up, silently dropping DNS updates.
-    environment.etc."NetworkManager/NetworkManager.conf".text = lib.generators.toINI { } {
+    environment.etc."NetworkManager/conf.d/00-nixos.conf".text = lib.generators.toINI { } {
       main.rc-manager = if config.programs.resolvconf.enable then "resolvconf" else "symlink";
     };
 


### PR DESCRIPTION
Issue: NetworkManager get build in nixpkgs with a hardcoded resolfconf and rc-manager="auto". If /modules/programs/resolveconf never gets enabled it never gets configured and silently fails.  

Fix:  set rc-manager explicitly based on if  programs.resolvconf.enable then it  contributes its entries via resloveconf  else it symlinks its own resolveconf.

Tested on hardware, in different configurations:
 - standalone NM : /etc/resolv.conf written by  NM, resolution works 
 - NM with programs.resolvconf.enable: NM submits via openresolv and the file is generated by resolvconf