### PR TITLE
modules/networkmanager: add `settings` option

### DIFF
--- a/docs/manpage-urls.json
+++ b/docs/manpage-urls.json
@@ -29,6 +29,7 @@
   "labwc(1)": "https://man.archlinux.org/man/labwc.1",
   "login.defs(5)": "https://man.archlinux.org/man/login.defs.5",
   "mount(8)": "https://man.archlinux.org/man/mount.8",
+  "NetworkManager.conf(5)": "https://man.archlinux.org/man/NetworkManager.conf.5",
   "nix.conf(5)": "https://man.archlinux.org/man/nix.conf.5",
   "nvidia-persistenced(1)": "https://man.archlinux.org/man/nvidia-persistenced.1",
   "pam_env(8)": "https://man.archlinux.org/man/pam_env.8",

--- a/modules/services/networkmanager/default.nix
+++ b/modules/services/networkmanager/default.nix
@@ -7,6 +7,8 @@
 let
   cfg = config.services.networkmanager;
 
+  format = pkgs.formats.ini { };
+
   packages = [
     cfg.package
     pkgs.wpa_supplicant
@@ -30,25 +32,62 @@ in
         The package to use for `networkmanager`.
       '';
     };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          main.rc-manager = lib.mkOption {
+            type = lib.types.enum [
+              "auto"
+              "file"
+              "netconfig"
+              "none"
+              "resolvconf"
+              "symlink"
+              "unmanaged"
+            ];
+            default = "symlink";
+            description = ''
+              Set the `resolv.conf` management mode.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        `networkmanager` configuration. See {manpage}`NetworkManager.conf(5)`
+        for additional details.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    services.networkmanager.settings.main = lib.optionalAttrs config.programs.resolvconf.enable {
+      # nixpkgs builds NetworkManager with a hardcoded resolvconf path, so the
+      # default rc-manager=auto always selects resolvconf, even when nothing
+      # has set it up, silently dropping DNS updates.
+      rc-manager = lib.mkDefault "resolvconf";
+    };
+
     boot.kernelModules = [
       "ctr"
     ];
 
     environment.systemPackages = packages;
+    environment.etc."NetworkManager/conf.d/00-nixos.conf".source =
+      format.generate "00-nixos.conf" cfg.settings;
+
+    # TODO: add finit.services.reloadTriggers option
+    environment.etc."finit.d/network-manager.conf".text = lib.mkAfter ''
+
+      # reload trigger
+      # ${config.environment.etc."NetworkManager/conf.d/00-nixos.conf".source}
+    '';
 
     services.dbus.enable = true;
     services.dbus.packages = packages;
     services.udev.packages = packages;
-
-    # nixpkgs builds NetworkManager with a hardcoded resolvconf path, so the
-    # default rc-manager=auto always selects resolvconf, even when nothing
-    # has set it up, silently dropping DNS updates.
-    environment.etc."NetworkManager/conf.d/00-nixos.conf".text = lib.generators.toINI { } {
-      main.rc-manager = if config.programs.resolvconf.enable then "resolvconf" else "symlink";
-    };
 
     finit.services.network-manager = {
       description = "network manager service";


### PR DESCRIPTION
realized we didn't expose a `settings` option yet! `networkmanager` supports a configuration reload on `SIGHUP`, so we can trigger a reload on configuration change directly through `finit`

@N1meses are you able to test this? apologies if i made any mistakes... i very quickly threw this together and don't have a `udev` specialization on my system at the moment...