### PR TITLE
Fix luks and lvm dm udev sync

### DIFF
--- a/modules/filesystems/luks.nix
+++ b/modules/filesystems/luks.nix
@@ -68,17 +68,23 @@
         "aes_generic"
       ];
 
-      boot.initrd.fileSystemImportCommands = lib.mkOrder 500 (
-        lib.concatStringsSep "\n" (
-          lib.mapAttrsToList (
+      boot.initrd.finit.tasks.luks =
+        let
+          devices = lib.filterAttrs (_: fs: fs.fsType == "luks") config.fileSystems;
+        in
+        lib.mkIf (devices != { }) {
+          conditions =
+            lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
+            ++ lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
+            ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
+            ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ];
+
+          tty = "@console";
+          script = lib.concatMapAttrsStringSep "\n" (
             name: dev:
-            let
-              fsOpts = lib.concatStringsSep " " dev.options;
-            in
-            "cryptsetup open ${fsOpts} ${dev.device} ${name}"
-          ) (lib.filterAttrs (_: fs: fs.fsType == "luks") config.fileSystems)
-        )
-      );
+            "DM_DISABLE_UDEV=1 cryptsetup open ${lib.concatStringsSep " " dev.options} ${dev.device} ${name}"
+          ) devices;
+        };
     })
   ];
 }

--- a/modules/filesystems/lvm.nix
+++ b/modules/filesystems/lvm.nix
@@ -51,12 +51,19 @@
     (lib.mkIf config.boot.initrd.supportedFilesystems.lvm.enable {
       boot.initrd.kernelModules = [ "dm_mod" ];
 
-      boot.initrd.fileSystemImportCommands = lib.mkOrder 600 (
-        if config.services.udev.enable || !config.services.mdevd.enable then
-          "lvm vgchange -ay"
-        else
-          "lvm vgchange -ay --noudevsync\ndmsetup mknodes"
-      );
+      boot.initrd.finit.tasks.lvm = {
+        conditions =
+          lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
+          ++ lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
+          ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
+          ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ]
+          ++ lib.optional config.boot.initrd.supportedFilesystems.luks.enable [ "task/luks/success" ];
+
+        script = ''
+          lvm vgchange -ay --noudevsync
+          dmsetup mknodes
+        '';
+      };
     })
   ];
 }


### PR DESCRIPTION
Turned out to be a very simple fix though a little counter intuitive. This also works on the new keventd module aswell with no changes needed, and will hopefully do the same for any other new device managers.