### PR TITLE
modules/services/openssh: fix PasswordAuthentication being bypassed via keyboard-interactive

### DIFF
--- a/modules/services/openssh/default.nix
+++ b/modules/services/openssh/default.nix
@@ -212,7 +212,8 @@ in
 
           KbdInteractiveAuthentication = lib.mkOption {
             type = lib.types.bool;
-            default = true;
+            default = cfg.settings.PasswordAuthentication;
+            defaultText = lib.literalExpression "config.services.openssh.settings.PasswordAuthentication";
             description = ''
               Specifies whether keyboard-interactive authentication is allowed.
             '';


### PR DESCRIPTION
Issue: services.openssh.settings.PasswordAuthentication = false does not stop password logins. KbdInteractiveAuthentication defaults to true, and it's a separate SSH auth method, with UsePAM yes it reaches pam_unix, which prompts for the same password.

Fix: default KbdInteractiveAuthentication to PasswordAuthentication, while an explicit = true still enables PAM 2FA.