### PR TITLE
modules/services/dhcpcd: fix reseolveconf not being in path

### DIFF
--- a/modules/services/dhcpcd/default.nix
+++ b/modules/services/dhcpcd/default.nix
@@ -225,6 +225,10 @@ in
       pid = "/run/dhcpcd/pid";
       type = "forking";
       conditions = "service/syslogd/ready";
+
+      path = lib.optionals config.programs.resolvconf.enable [
+        config.programs.resolvconf.package
+      ];
     };
 
     finit.tmpfiles.rules = [


### PR DESCRIPTION
issue: dhcpcd cannot find  reloveconf in its path so it fallsback to writing it itself, which conflicts with other services

fix: put resolvconf in the path of its service