### PR TITLE
modules/services/iwd: make EnableNetworkConfiguration overridable

### DIFF
--- a/modules/services/dhcpcd/default.nix
+++ b/modules/services/dhcpcd/default.nix
@@ -225,6 +225,10 @@ in
       pid = "/run/dhcpcd/pid";
       type = "forking";
       conditions = "service/syslogd/ready";
+
+      path = lib.optionals config.programs.resolvconf.enable [
+        config.programs.resolvconf.package
+      ];
     };
 
     finit.tmpfiles.rules = [

--- a/modules/services/iwd/default.nix
+++ b/modules/services/iwd/default.nix
@@ -48,7 +48,10 @@ in
   config = lib.mkIf cfg.enable {
     services.iwd.settings = {
       General = {
-        EnableNetworkConfiguration = true;
+        # upstream defaults this to false, expecting another service to own IP.
+        # default it on so iwd works standalone, but let users hand IP
+        # configuration to a dhcp client instead.
+        EnableNetworkConfiguration = lib.mkDefault true;
       };
 
       Network = {


### PR DESCRIPTION
services/iwd/default.nix sets EnableNetworkConfiguration = true as a plain definition.  Setting it to false to let dhcpcd own IP configuration, which is what iwd upstream expects, results in conflicting definitions.
Upstream defaults the option to off (iwd.config(5): "The network configuration feature is disabled by default"; src/netconfig.c treats an absent key as false; doc/main.conf ships it commented out). Keeping finix's true as a default preserves standalone iwd exactly as it is today and makes the other configuration expressible with a plain false.

Tested in a VM: with EnableNetworkConfiguration = false, iwd associates and assigns no address, and dhcpcd obtains the lease, registers with resolvconf and resolves DNS. Requires #144 for the DNS half.