### PR TITLE
initrd: order luks/lvm/mounts on device wait-dev tasks

### DIFF
--- a/modules/filesystems/luks.nix
+++ b/modules/filesystems/luks.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  utils,
   ...
 }:
 {
@@ -73,11 +74,9 @@
           devices = lib.filterAttrs (_: fs: fs.fsType == "luks") config.fileSystems;
         in
         lib.mkIf (devices != { }) {
-          conditions =
-            lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
-            ++ lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
-            ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
-            ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ];
+          conditions = map (dev: "task/wait-dev-${utils.escapePath dev.device}/success") (
+            lib.attrValues devices
+          );
 
           tty = "@console";
           script = lib.concatMapAttrsStringSep "\n" (

--- a/modules/filesystems/lvm.nix
+++ b/modules/filesystems/lvm.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  utils,
   ...
 }:
 {
@@ -52,12 +53,9 @@
       boot.initrd.kernelModules = [ "dm_mod" ];
 
       boot.initrd.finit.tasks.lvm = {
-        conditions =
-          lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
-          ++ lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
-          ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
-          ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ]
-          ++ lib.optional config.boot.initrd.supportedFilesystems.luks.enable [ "task/luks/success" ];
+        conditions = map (fs: "task/wait-dev-${utils.escapePath fs.device}/success") (
+          lib.filter (fs: fs.fsType == "lvm") (lib.attrValues config.fileSystems)
+        );
 
         script = ''
           lvm vgchange -ay --noudevsync

--- a/modules/finit/mount.nix
+++ b/modules/finit/mount.nix
@@ -68,13 +68,18 @@ let
     ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ];
 
   names = map (fs: utils.escapePath fs.mountPoint) mountable;
+
+  waitDevs = lib.filter (fs: needsWaitDev fs && (fs.neededForBoot || isPseudo fs)) (
+    lib.attrValues config.fileSystems
+  );
+  waitDevName = fs: utils.escapePath (if isPseudo fs then fs.device else fs.mountPoint);
 in
 {
   config = {
     boot.initrd.finit.tasks = lib.mkMerge [
-      (lib.genAttrs' (lib.filter needsWaitDev mountable) (
+      (lib.genAttrs' waitDevs (
         fs:
-        lib.nameValuePair "wait-dev-${utils.escapePath fs.mountPoint}" {
+        lib.nameValuePair "wait-dev-${waitDevName fs}" {
           conditions = deviceConditions;
           script = ''
             # 90s total timeout, polled every 0.1s (busybox sleep supports fractional)


### PR DESCRIPTION
Some improvements to how luks and lvm are handled with the new parallelism