### PR TITLE
fix(networking): seed networking.hosts with IP-keyed entries

### DIFF
--- a/modules/networking/default.nix
+++ b/modules/networking/default.nix
@@ -61,7 +61,7 @@ in
         };
       '';
       description = ''
-        Locally defined maps of hostnames to IP addresses.
+        Locally defined maps of IP addresses to hostnames.
       '';
     };
   };
@@ -88,8 +88,9 @@ in
     };
 
     networking.hosts = {
-      localhost = [ "127.0.0.1" ];
-      ${config.networking.hostName} = [ "127.0.0.2" ];
+      "127.0.0.1" = [ "localhost" ];
+      "::1" = [ "localhost" ];
+      "127.0.0.2" = [ config.networking.hostName ];
     };
 
     boot.initrd = {


### PR DESCRIPTION
Follow-up to #153.

**Problem**: the default seed for `networking.hosts` used hostname-keyed entries while the option type, its example, and the `/etc/hosts` renderer are all IP-keyed. A default system rendered:

```
localhost 127.0.0.1
<hostname> 127.0.0.2
```

`localhost` never resolved, which breaks anything that listens on or connects to it by name (observed: postgresql with default `listen_addresses = "localhost"` failing to start).

**Fix**: seed valid IP-keyed entries matching the renderer and NixOS defaults (`127.0.0.1`/`::1` → `localhost`, `127.0.0.2` → `hostName`), and correct the option description.

**Validation**: evaluated a minimal system with `hostName = "testbox"` on this branch; rendered `/etc/hosts`:

```
127.0.0.1 localhost
127.0.0.2 testbox
::1 localhost
```