### PR TITLE
modules/services/mdevd: prepend kmod so its modprobe isn't shadowed by busybox

### DIFF
--- a/modules/services/mdevd/default.nix
+++ b/modules/services/mdevd/default.nix
@@ -45,7 +45,7 @@ let
 
   # Insert modules for devices with a modalias.
   # Use @ prefix to run via /bin/sh on add events.
-  modaliasRule = ''-$MODALIAS=.* 0:0 660 @modprobe --quiet "$MODALIAS"'';
+  modaliasRule = ''-$MODALIAS=.* 0:0 660 @${pkgs.kmod}/bin/modprobe --quiet "$MODALIAS"'';
 
   # We need symlinks in /dev/disk/{by-id,by-label,by-uuid,by-partlabel,by-partuuid}
   # so we run this script for block device events.
@@ -196,7 +196,6 @@ in
       path = [
         config.programs.coreutils.package
         pkgs.execline
-        pkgs.kmod
         pkgs.util-linux
       ];
     };


### PR DESCRIPTION
Issue: With programs.coreutils.package = pkgs.busybox, mdevd's modalias-based autoload silently fails: no input (evdev), wifi, or touchpad, while by-name module loading and the console keyboard still work.

Fix: put pkgs.kmod ahead of coreutils in the path.

tested on: hardware with mdvd, seatd, busybox