### PR TITLE
modules/xorg+mdevd: nlgroups changes

### DIFF
--- a/modules/programs/xorg/default.nix
+++ b/modules/programs/xorg/default.nix
@@ -123,6 +123,9 @@ in
       xf86-input-libinput'
     ];
 
+    # allows hotplugging in xserver with mdevd
+    services.mdevd.nlgroups = 4;
+
     environment.pathsToLink = [
       "/share/X11"
       "/share/xsessions"

--- a/modules/services/mdevd/default.nix
+++ b/modules/services/mdevd/default.nix
@@ -134,7 +134,7 @@ in
       type = with lib.types; nullOr ints.unsigned;
       default = null;
       description = ''
-        After `mdevd` has handled the uevents, rebroadcast them to the netlink groups identified
+        After `mdevd` has handled the uevents for hotplugged devices, rebroadcast them to the netlink groups identified
         by the mask {option}`nlgroups`.
 
         ::: {.note}
@@ -202,10 +202,7 @@ in
 
     finit.run.coldplug = {
       description = "cold plugging system";
-      command =
-        "${cfg.package}/bin/mdevd-coldplug"
-        + lib.optionalString (cfg.nlgroups != null) " -O ${toString cfg.nlgroups}"
-        + lib.optionalString cfg.debug " -v 3";
+      command = "${cfg.package}/bin/mdevd-coldplug" + lib.optionalString cfg.debug " -v 3";
       runlevels = "S";
       conditions = "service/mdevd/ready";
       cgroup.name = "init";


### PR DESCRIPTION
Removed `nlgroups` option for the coldplug `mdevd setup task.

Added a check to the `xorg` module that sets the default `services.mdevd.nlgroups` option to `4` if `xorg` is enabled, allowing you to hotplug devices correctly inside an xserver.