### PR TITLE
nvidia - prime support, and more

### DIFF
--- a/modules/hardware/default.nix
+++ b/modules/hardware/default.nix
@@ -28,6 +28,7 @@ in
     ./cpu/amd-ucode.nix
     ./cpu/intel-ucode.nix
     ./video/nvidia.nix
+    ./video/nvidia-prime.nix
   ];
 
   options = {

--- a/modules/hardware/video/nvidia-prime.nix
+++ b/modules/hardware/video/nvidia-prime.nix
@@ -1,0 +1,171 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.hardware.nvidia.prime;
+
+  gpuIDs = lib.filter (x: x != null) [
+    cfg.intelBusId
+    cfg.nvidiaBusId
+    cfg.amdgpuBusId
+  ];
+
+  busIdType = lib.types.strMatching "([[:print:]]+[:@][0-9]{1,3}:[0-9]{1,2}:[0-9])?";
+in
+{
+  options.hardware.nvidia.prime = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.offload.enable || cfg.sync.enable;
+      defaultText = lib.literalExpression "config.hardware.nvidia.prime.offload.enable || config.hardware.nvidia.prime.sync.enable";
+      readOnly = true;
+      description = ''
+        Whether to enable nvidia PRIME support.
+      '';
+    };
+
+    offload.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable PRIME offload mode. The iGPU handles display output
+        and general rendering; the NVIDIA GPU is used only when explicitly
+        requested (via the nvidia-offload wrapper or DRI_PRIME env var).
+        Cannot be used together with prime.sync.enable.
+      '';
+    };
+
+    offload.enableOffloadCmd = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to add an `nvidia-offload` wrapper script to systemPackages.
+        Run `nvidia-offload <program>` to launch a program on the NVIDIA GPU.
+        Requires prime.offload.enable = true.
+      '';
+    };
+
+    sync.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable PRIME sync mode. Both GPUs are active simultaneously;
+        the NVIDIA GPU renders and the iGPU handles display. Eliminates tearing
+        but uses more power than offload mode. Cannot be used with
+        prime.offload.enable.
+      '';
+    };
+
+    intelBusId = lib.mkOption {
+      type = lib.types.nullOr busIdType;
+      default = null;
+      example = "PCI:0:2:0";
+      description = ''
+        The PCI bus ID of the Intel iGPU. Find it with:
+          lspci | grep -i intel | grep -i vga
+        then convert the hex address (e.g. 00:02.0) to PCI:0:2:0.
+      '';
+    };
+
+    nvidiaBusId = lib.mkOption {
+      type = lib.types.nullOr busIdType;
+      default = null;
+      example = "PCI:1:0:0";
+      description = ''
+        The PCI bus ID of the NVIDIA GPU. Find it with:
+          lspci | grep -i nvidia
+        then convert the hex address (e.g. 01:00.0) to PCI:1:0:0.
+      '';
+    };
+
+    amdgpuBusId = lib.mkOption {
+      type = lib.types.nullOr busIdType;
+      default = null;
+      example = "PCI:4:0:0";
+      description = ''
+        The PCI bus ID of the AMD iGPU (for AMD+NVIDIA Optimus laptops).
+        Find it with: lspci | grep -i amd | grep -i vga
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.offload.enable && cfg.sync.enable);
+        message = "config.hardware.nvidia.prime.offload.enable and config.hardware.nvidia.prime.sync.enable are mutually exclusive";
+      }
+      {
+        assertion = cfg.offload.enableOffloadCmd -> cfg.offload.enable;
+        message = "config.hardware.nvidia.prime.offload.enableOffloadCmd requires config.hardware.nvidia.prime.offload.enable = true";
+      }
+      {
+        assertion = cfg.enable -> (cfg.nvidiaBusId != null && lib.length gpuIDs >= 2);
+        message = "PRIME requires config.hardware.nvidia.prime.nvidiaBusId and at least one of config.hardware.nvidia.prime.intelBusId / config.hardware.nvidia.prime.amdgpuBusId to be set";
+      }
+    ];
+
+    hardware.nvidia.enable = lib.mkForce true;
+
+    environment.etc =
+      let
+        igpuId =
+          if cfg.intelBusId != null then
+            "modesetting"
+          else if cfg.amdgpuBusId != null then
+            "amdgpu"
+          else
+            null;
+      in
+      lib.mkIf config.programs.xorg.enable or false {
+        "X11/xorg.conf.d/10-nvidia-prime.conf".text =
+          lib.optionalString (cfg.intelBusId != null) ''
+            Section "Device"
+              Identifier "modesetting"
+              Driver "modesetting"
+              BusID "${cfg.intelBusId}"
+              Option "DRI" "3"
+            EndSection
+          ''
+          + lib.optionalString (cfg.amdgpuBusId != null) ''
+            Section "Device"
+              Identifier "amdgpu"
+              Driver "amdgpu"
+              BusID "${cfg.amdgpuBusId}"
+            EndSection
+          ''
+          + lib.optionalString (cfg.nvidiaBusId != null) ''
+            Section "Device"
+              Identifier "nvidia"
+              Driver "nvidia"
+              BusID "${cfg.nvidiaBusId}"
+              ${lib.optionalString cfg.offload.enable ''Option "AllowEmptyInitialConfiguration"''}
+            EndSection
+          ''
+          + lib.optionalString (cfg.sync.enable && igpuId != null) ''
+            Section "ServerLayout"
+              Identifier "layout"
+              Screen "Screen-nvidia[0]"
+              Inactive "${igpuId}"
+              Option "AllowNVIDIAGPUScreens"
+            EndSection
+          '';
+      };
+
+    environment.systemPackages =
+      let
+        script = pkgs.writeShellScriptBin "nvidia-offload" ''
+          export __NV_PRIME_RENDER_OFFLOAD=1
+          export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
+          export __GLX_VENDOR_LIBRARY_NAME=nvidia
+          export __VK_LAYER_NV_optimus=NVIDIA_only
+
+          exec "$@"
+        '';
+      in
+      lib.optionals cfg.offload.enableOffloadCmd [ script ];
+  };
+}

--- a/modules/hardware/video/nvidia.nix
+++ b/modules/hardware/video/nvidia.nix
@@ -52,27 +52,48 @@ in
       description = "Whether to enable NVIDIA driver support.";
     };
 
-    powerManagement.enable = lib.mkOption {
+    power.suspend.enable = lib.mkOption {
       type = lib.types.bool;
       default = false;
       description = ''
-        Whether to enable experimental power management through systemd. For
-        more information, see the NVIDIA docs, on Chapter 21. Configuring
-        Power Management Support.
+        Whether to preserve video memory allocations across system suspend and
+        hibernate. For more information, see the NVIDIA docs, on Chapter 21.
+        Configuring Power Management Support.
       '';
     };
 
-    powerManagement.kernelSuspendNotifier = lib.mkOption {
-      type = lib.types.bool;
-      default = cfg.kernelModule == "open" && lib.versionAtLeast cfg.package.version "595";
+    power.suspend.notifier = lib.mkOption {
+      type = lib.types.enum [
+        "kernel"
+        "userspace"
+      ];
+      default =
+        if cfg.kernelModule == "open" && lib.versionAtLeast cfg.package.version "595" then
+          "kernel"
+        else
+          "userspace";
       defaultText = lib.literalExpression ''
-        config.hardware.nvidia.kernelModule == "open" && lib.versionAtLeast config.hardware.nvidia.package.version "595"
+        if config.hardware.nvidia.kernelModule == "open" && lib.versionAtLeast config.hardware.nvidia.package.version "595" then "kernel" else "userspace"
       '';
       description = ''
-        Whether to enable NVIDIA driver support for kernel suspend notifiers,
-        which allows the driver to be notified of suspend and resume events by
-        the kernel, rather than relying on systemd services. Requires NVIDIA
-        driver version 595 or newer, and the open source kernel modules.
+        How the NVIDIA driver is notified of system suspend and resume events
+        when `power.suspend.enable` is set:
+
+        - `kernel`: the kernel notifies the driver directly. Requires NVIDIA
+          driver version 595 or newer, and the open source kernel modules.
+        - `userspace`: relies on nvidia-sleep.sh being run by the sleep backend
+          (requires a sleep backend, e.g. programs.zzz).
+      '';
+    };
+
+    power.runtime.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable fine-grained dynamic power management. When enabled,
+        the NVIDIA GPU is powered down when not in use. Only works in PRIME
+        offload mode (prime.offload.enable = true). Requires kernel >= 5.5 and
+        a Turing or newer GPU. Sets NVreg_DynamicPowerManagement=0x02.
       '';
     };
 
@@ -138,15 +159,15 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.powerManagement.enable -> lib.versionAtLeast cfg.package.version "430.09";
+        assertion = cfg.power.suspend.enable -> lib.versionAtLeast cfg.package.version "430.09";
         message = "Required files for driver based power management only exist on versions >= 430.09.";
       }
 
       {
         assertion =
-          (cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier)
+          (cfg.power.suspend.enable && cfg.power.suspend.notifier == "userspace")
           -> config.providers.resumeAndSuspend.backend != "none";
-        message = "Power management without `kernelSuspendNotifier` requires a sleep backend. Enable programs.zzz (programs.zzz.enable = true).";
+        message = "`power.suspend.notifier = \"userspace\"` requires a sleep backend. Enable programs.zzz (programs.zzz.enable = true).";
       }
 
       {
@@ -166,9 +187,14 @@ in
 
       {
         assertion =
-          cfg.powerManagement.kernelSuspendNotifier
+          cfg.power.suspend.notifier == "kernel"
           -> (cfg.kernelModule == "open" && lib.versionAtLeast cfg.package.version "595");
-        message = "NVIDIA driver support for kernel suspend notifiers requires NVIDIA driver version 595 or newer, and the open source kernel modules.";
+        message = "`power.suspend.notifier = \"kernel\"` requires NVIDIA driver version 595 or newer, and the open source kernel modules.";
+      }
+
+      {
+        assertion = cfg.power.runtime.enable -> cfg.prime.offload.enable;
+        message = "`power.runtime.enable` requires `prime.offload.enable`.";
       }
     ];
 
@@ -219,10 +245,11 @@ in
 
       kernelParams =
         lib.optionals (cfg.kernelModule == "open") [ "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1" ]
-        ++ lib.optionals (cfg.powerManagement.enable && cfg.powerManagement.kernelSuspendNotifier) [
+        ++ lib.optionals (cfg.power.suspend.enable && cfg.power.suspend.notifier == "kernel") [
           "nvidia.NVreg_UseKernelSuspendNotifiers=1"
         ]
-        ++ lib.optionals cfg.powerManagement.enable [ "nvidia.NVreg_PreserveVideoMemoryAllocations=1" ]
+        ++ lib.optionals cfg.power.suspend.enable [ "nvidia.NVreg_PreserveVideoMemoryAllocations=1" ]
+        ++ lib.optionals cfg.power.runtime.enable [ "nvidia.NVreg_DynamicPowerManagement=0x02" ]
         ++ lib.optionals (config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport) [
           "ibt=off"
         ]
@@ -274,6 +301,16 @@ in
         KERNEL=="card*", SUBSYSTEM=="drm", GROUP="video", MODE="0660"
         KERNEL=="renderD*", SUBSYSTEM=="drm", GROUP="render", MODE="0660"
       '')
+    ]
+    ++ lib.optionals cfg.power.runtime.enable [
+      (pkgs.writeTextDir "lib/udev/rules.d/80-nvidia-pm.rules" ''
+        ACTION=="bind",   SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
+        ACTION=="bind",   SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"
+        ACTION=="bind",   SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", TEST=="power/control", ATTR{power/control}="auto"
+        ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="on"
+        ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="on"
+        ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", TEST=="power/control", ATTR{power/control}="on"
+      '')
     ];
 
     hardware.graphics.extraPackages = [
@@ -290,7 +327,7 @@ in
     hardware.firmware = lib.optional cfg.gsp.enable cfg.package.firmware;
 
     providers.resumeAndSuspend.hooks =
-      lib.optionalAttrs (cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier)
+      lib.optionalAttrs (cfg.power.suspend.enable && cfg.power.suspend.notifier == "userspace")
         {
           nvidia-suspend = {
             event = "suspend";

--- a/modules/programs/xorg/nvidia.nix
+++ b/modules/programs/xorg/nvidia.nix
@@ -6,6 +6,22 @@
 }:
 let
   cfg = config.hardware.nvidia;
+
+  igpuId =
+    if cfg.prime.intelBusId != null then
+      "modesetting"
+    else if cfg.prime.amdgpuBusId != null then
+      "amdgpu"
+    else
+      null;
+
+  screenDevice =
+    if cfg.prime.offload.enable && igpuId != null then
+      igpuId
+    else if cfg.prime.sync.enable && cfg.prime.nvidiaBusId != null then
+      "nvidia"
+    else
+      "Device-nvidia[0]";
 in
 {
   options.hardware.nvidia.reduceTearing = lib.mkOption {
@@ -45,7 +61,7 @@ in
 
       Section "Screen"
         Identifier "Screen-nvidia[0]"
-        Device "Device-nvidia[0]"
+        Device "${screenDevice}"
         Option "RandRRotation" "on"
         ${lib.optionalString cfg.reduceTearing ''
           Option "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"


### PR DESCRIPTION
minor rework of #128, so credits for this code go to @FixeQD :bowing_man:

introduces a breaking change... so:

```
hardware.nvidia.powerManagement.enable = true;
hardware.nvidia.powerManagement.kernelSuspendNotifier = true;
```

becomes
```
hardware.nvidia.power.suspend.enable = true;
hardware.nvidia.power.suspend.notifier = "kernel";
```