### PR TITLE
modules/hardware/console: make loadkmap a finit task

### DIFF
--- a/modules/hardware/console.nix
+++ b/modules/hardware/console.nix
@@ -19,10 +19,11 @@ let
         loadkeys --bkeymap "${km}" >$out
       '';
 
-  loadkmapScript = pkgs.writeScript "loadkmap-console" ''
-    #!${pkgs.busybox}/bin/sh
-    exec ${pkgs.busybox}/bin/loadkmap < ${cfg.binaryKeyMap}
-  '';
+  loadkmapTask = {
+    description = "load console keymap";
+    conditions = "dev/console";
+    command = "${pkgs.busybox}/bin/loadkmap < ${cfg.binaryKeyMap}";
+  };
 in
 {
   options = {
@@ -71,17 +72,9 @@ in
     # Console node ownership and mode; mdevd has no defaults for this.
     services.mdevd.coldplugRules = "-console 0:${toString config.ids.gids.tty} 600";
 
-    finit.tasks.loadkmap = {
-      description = "load console keymap";
-      conditions = "dev/console";
-      command = loadkmapScript;
-    };
+    finit.tasks.loadkmap = loadkmapTask;
 
-    boot.initrd.finit.tasks.loadkmap = {
-      description = "load console keymap";
-      conditions = "dev/console";
-      script = "loadkmap < ${cfg.binaryKeyMap}";
-    };
+    boot.initrd.finit.tasks.loadkmap = loadkmapTask;
 
     finit.tasks.setvesablank =
       let

--- a/modules/hardware/console.nix
+++ b/modules/hardware/console.nix
@@ -18,6 +18,11 @@ let
       ''
         loadkeys --bkeymap "${km}" >$out
       '';
+
+  loadkmapScript = pkgs.writeScript "loadkmap-console" ''
+    #!${pkgs.busybox}/bin/sh
+    exec ${pkgs.busybox}/bin/loadkmap < ${cfg.binaryKeyMap}
+  '';
 in
 {
   options = {
@@ -63,15 +68,20 @@ in
     # Include binary keymap in the initramfs.
     boot.initrd.contents = [ { source = cfg.binaryKeyMap; } ];
 
-    # Use the device-manager to load the keymap rather
-    # than injecting somewhere into the early boot script.
-    services.mdevd.coldplugRules = "-console 0:${toString config.ids.gids.tty} 600 +redirfd -r 0 ${cfg.binaryKeyMap} loadkmap";
+    # Console node ownership and mode; mdevd has no defaults for this.
+    services.mdevd.coldplugRules = "-console 0:${toString config.ids.gids.tty} 600";
 
-    services.udev.packages = [
-      (pkgs.writeTextDir "etc/udev/rules.d/loadkmap" ''
-        KERNEL=="console", SUBSYSTEM=="tty", RUN+="${pkgs.busybox}/bin/loadkmap <${cfg.binaryKeyMap}"
-      '')
-    ];
+    finit.tasks.loadkmap = {
+      description = "load console keymap";
+      conditions = "dev/console";
+      command = loadkmapScript;
+    };
+
+    boot.initrd.finit.tasks.loadkmap = {
+      description = "load console keymap";
+      conditions = "dev/console";
+      script = "loadkmap < ${cfg.binaryKeyMap}";
+    };
 
     finit.tasks.setvesablank =
       let


### PR DESCRIPTION
Issue: keymaps were not correctly loading in stage 1 and 2 with broken filenames and for the udev path and RUN declaration.

Fix: make loadkmaps a finit task for all device managers, also adds a task in initrd to laodkeymaps

Tested on: udevd, mdevd, gardendevd also the initramfs on a encrypted-root device
tho more test are welcome