### PR TITLE
modules/filesystems/zfs: fix boot hang on native datasets

### DIFF
--- a/modules/filesystems/zfs.nix
+++ b/modules/filesystems/zfs.nix
@@ -113,7 +113,7 @@
                 tries=900
                 i=0
                 while [ "$i" -lt "$tries" ]; do
-                  if zpool list "${pool}" >/dev/null 2>&1 || zpool import -f "${pool}"; then
+                  if zpool list "${pool}" >/dev/null 2>&1 || zpool import -N -f "${pool}"; then
                     ${lib.concatMapStringsSep "\n" (k: ''zfs load-key "${k}"'') (keysFor pool)}
                     exit 0
                   fi


### PR DESCRIPTION
Issue: zfs native datasets get imported and automatically mounted at their native mount points in stage 1. this conflicts with stage 1's /nix if one has tank/nix and causes hang on boot.

fix: use the -N flag which prevents the datasets from being auto mounted in stage 1.  the dataset tank/nix would then get mounted at /sysroot/nix which becomes /nix after switch-root and with that the correct mount point for the dataset.

tested on zfs device
in theory legacy-datasets are unaffected since they never auto mount to begin with and -N would no-op for them. but i would rather have it tested then guess 