### PR TITLE
modules/services/docker: fix reference to non-existent option config.boot.zfs.package

### DIFF
--- a/modules/services/docker/default.nix
+++ b/modules/services/docker/default.nix
@@ -219,9 +219,9 @@ in
     services.docker.extraPackages = [
       config.services.nftables.package or pkgs.nftables
     ]
-    ++ lib.optionals (cfg.settings.storage-driver == "zfs") [
-      config.boot.zfs.package
-    ];
+    ++ lib.optionals (
+      cfg.settings.storage-driver == "zfs"
+    ) config.boot.supportedFilesystems.zfs.packages;
 
     boot.kernelModules = [
       "bridge"


### PR DESCRIPTION
issue: if one runs docker and zfs, it references a non existent i option.boot.zfs.packages. this fails at eval
(pobably from nixos module copied over)

fix: reference config.boot.supportedFilesystems.zfs.packages instead

tested; will eval now and still show Storage Driver: zfs 