### PR TITLE
ifupdown-ng and dhcpcd: Fix /etc/resolv.conf generation

### DIFF
--- a/modules/programs/ifupdown-ng/default.nix
+++ b/modules/programs/ifupdown-ng/default.nix
@@ -1,4 +1,5 @@
 {
+  modules,
   config,
   pkgs,
   lib,
@@ -14,6 +15,9 @@ let
   multiValueType = with lib.types; nullOr (coercedTo str lib.singleton (listOf str));
 in
 {
+
+  imports = [ modules.dhcpcd ];
+
   options.programs.ifupdown-ng = {
     enable = lib.mkOption {
       type = lib.types.bool;
@@ -158,6 +162,11 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+
+    # Needed for /etc/dhcpcd.conf
+    services.dhcpcd.enable = true;
+    finit.services.dhcpcd.enable = lib.mkDefault false;
+
     programs.ifupdown-ng.extraArgs = [ "-a" ] ++ lib.optionals cfg.debug [ "-v" ];
 
     environment.systemPackages = [ cfg.package ];

--- a/modules/services/dhcpcd/default.nix
+++ b/modules/services/dhcpcd/default.nix
@@ -163,6 +163,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+
+    # Rendering this config file is required for other services that use dhcpcd
+    environment.etc."dhcpcd.conf".source = cfg.configFile;
+
     services.dhcpcd.extraArgs = [
       "-B"
       "-f"


### PR DESCRIPTION
In imperative distros installing dhcpcd creates /etc/dhcpcd.conf file with useful defaults like querying nameservers. This change makes dhcpcd module render that file for cases where dhcpcd used as dependency.

Second commit makes ifupdown-ng dependent on dhcpcd for rendering this file and by default switches off finit's dhcpcd service to not be in conflict with each other.

Also checkout https://github.com/NixOS/nixpkgs/pull/536753 for nixpkgs ifupdown-ng update.