### PR TITLE
feat(services): add avahi module

### DIFF
--- a/docs/manpage-urls.json
+++ b/docs/manpage-urls.json
@@ -4,6 +4,8 @@
   "atd(8)": "https://man.archlinux.org/man/atd.8",
   "at.allow(5)": "https://man.archlinux.org/man/at.allow.5",
   "at.deny(5)": "https://man.archlinux.org/man/at.deny.5",
+  "avahi-daemon(8)": "https://man.archlinux.org/man/avahi-daemon.8",
+  "avahi-daemon.conf(5)": "https://man.archlinux.org/man/avahi-daemon.conf.5",
   "cap_from_text(3)": "https://man.archlinux.org/man/cap_from_text.3",
   "capabilities(7)": "https://man.archlinux.org/man/capabilities.7",
   "chronyd(8)": "https://man.archlinux.org/man/chronyd.8",

--- a/modules/services/avahi/default.nix
+++ b/modules/services/avahi/default.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.avahi;
+
+  mkValueString =
+    v:
+    if v == true then
+      "yes"
+    else if v == false then
+      "no"
+    else
+      lib.generators.mkValueStringDefault { } v;
+
+  format = pkgs.formats.ini {
+    mkKeyValue = lib.generators.mkKeyValueDefault { inherit mkValueString; } "=";
+    listToValue = lib.concatMapStringsSep ", " mkValueString;
+  };
+
+  enableDbus = cfg.settings.server.enable-dbus or true;
+in
+{
+  options.services.avahi = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable [avahi](${pkgs.avahi.meta.homepage}) as a system service.
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.avahi;
+      defaultText = lib.literalExpression "pkgs.avahi";
+      description = ''
+        The package to use for `avahi`.
+      '';
+    };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable debug logging.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      description = ''
+        Additional arguments to pass to `avahi`. See {manpage}`avahi-daemon(8)`
+        for additional details.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      description = ''
+        `avahi` configuration. See {manpage}`avahi-daemon.conf(5)`
+        for additional details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.avahi.extraArgs = [ "--syslog" ] ++ lib.optionals cfg.debug [ "--debug" ];
+    services.avahi.settings = {
+      server = { };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."avahi/avahi-daemon.conf".source = format.generate "avahi-daemon.conf" cfg.settings;
+
+    # TODO: add finit.services.reloadTriggers option
+    environment.etc."finit.d/avahi-daemon.conf".text = lib.mkAfter ''
+
+      # reload trigger
+      # ${config.environment.etc."avahi/avahi-daemon.conf".source}
+    '';
+
+    finit.services.avahi-daemon = {
+      description = "avahi daemon service";
+      conditions = [
+        "service/syslogd/ready"
+      ]
+      ++ lib.optionals enableDbus [ "service/dbus/ready" ];
+      command = lib.getExe' cfg.package "avahi-daemon";
+    };
+
+    services.dbus = lib.optionalAttrs enableDbus {
+      enable = true;
+      packages = [ cfg.package ];
+    };
+
+    users.users.avahi = {
+      description = "avahi-daemon privilege separation user";
+      home = "/var/empty";
+      group = "avahi";
+      isSystemUser = true;
+    };
+
+    users.groups.avahi = { };
+  };
+}


### PR DESCRIPTION
Adds `services.avahi` module. 

Tested, with this configuration:
```nix
services.avahi = {
  enable = true;
  hostName = "finixos";
  domainName = "local";
  browseDomains = [ "0pointer.de" "zeroconf.org" ];
  ipv4 = true;
  ipv6 = false;
  wideArea = false;
};
```
Nix generates this config:
```ini
[server]
host-name=finixos
browse-domains=0pointer.de, zeroconf.org
use-ipv4=yes
use-ipv6=no

domain-name=local
allow-point-to-point=no

[wide-area]
enable-wide-area=no

[publish]
disable-publishing=yes
disable-user-service-publishing=yes
publish-addresses=no
publish-hinfo=no
publish-workstation=no
publish-domain=no

[reflector]
enable-reflector=no
```

Relates to #105.