### PR TITLE
modules/programs/lxqt: fix `/share` paths

### DIFF
--- a/modules/programs/lxqt/default.nix
+++ b/modules/programs/lxqt/default.nix
@@ -221,8 +221,12 @@ in
       ];
 
     environment.pathsToLink = [
+      "/share/lxqt"
+      "/share/themes"
+      "/share/wallpapers"
       "/share/icons"
       "/share/pixmaps"
+      "/share/palettes"
     ];
 
     security.pam.environment = {


### PR DESCRIPTION
this _should_ properly include all the required `/share` paths that lxqt needs without needing a broad stroke `/share` inclusion. at least i think it does. "it works on my machine" and all that