### PR TITLE
modules/services/nix-daemon: dedup list values in nix.conf

### DIFF
--- a/modules/services/nix-daemon/default.nix
+++ b/modules/services/nix-daemon/default.nix
@@ -38,7 +38,7 @@ let
         else if lib.isFloat v then
           lib.floatToString v
         else if lib.isList v then
-          toString v
+          toString (lib.unique v)
         else if lib.isDerivation v then
           toString v
         else if builtins.isPath v then


### PR DESCRIPTION
The module sets `trusted-users = [ "root" ]` in its config block, so a user adding `[ "root" "alice" ]` renders as `trusted-users = root root alice`. Dedup at render time; `lib.unique` keeps first-occurrence order, so substituters ordering is unchanged. Output-only fix.

(Moving the default into the option declaration would also work, but that changes merge semantics for existing configs — a user list would replace root rather than append.)