### PR TITLE
modules/services/zram-swap: init

### DIFF
--- a/modules/services/zram-swap/default.nix
+++ b/modules/services/zram-swap/default.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.zram-swap;
+in
+{
+  options.services.zram-swap = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable swap on a compressed zram block device.
+      '';
+    };
+
+    memoryPercent = lib.mkOption {
+      type = lib.types.int;
+      default = 50;
+      description = ''
+        Size of the zram device as a percentage of total memory.
+      '';
+    };
+
+    algorithm = lib.mkOption {
+      type = lib.types.str;
+      default = "zstd";
+      example = "lz4";
+      description = ''
+        Compression algorithm passed to {command}`zramctl`.
+      '';
+    };
+
+    priority = lib.mkOption {
+      type = lib.types.int;
+      default = 5;
+      description = ''
+        Swap priority of the zram device. Higher values are preferred by
+        the kernel over lower-priority swap devices.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "zram" ];
+
+    finit.tasks.zram-swap = {
+      description = "zram swap (${toString cfg.memoryPercent}% RAM, ${cfg.algorithm})";
+      log = true;
+      command = pkgs.writeShellScript "zram-swap" ''
+        set -eu
+        export PATH=${
+          lib.makeBinPath [
+            pkgs.coreutils
+            pkgs.util-linux
+            pkgs.gnugrep
+            pkgs.gawk
+            pkgs.kmod
+          ]
+        }
+        modprobe zram || true
+        grep -q zram /proc/swaps && exit 0
+        mem_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+        dev=$(zramctl --find --size "$((mem_kb * ${toString cfg.memoryPercent} / 100))K" --algorithm ${cfg.algorithm})
+        mkswap "$dev" >/dev/null
+        swapon -p ${toString cfg.priority} "$dev"
+      '';
+    };
+  };
+}

--- a/modules/services/zram-swap/default.nix
+++ b/modules/services/zram-swap/default.nix
@@ -18,10 +18,13 @@ in
     };
 
     memoryPercent = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.positive;
       default = 50;
       description = ''
         Size of the zram device as a percentage of total memory.
+
+        Must be positive. Values above 100 are allowed because the device
+        stores compressed data; actual memory usage depends on compressibility.
       '';
     };
 
@@ -49,6 +52,10 @@ in
 
     finit.tasks.zram-swap = {
       description = "zram swap (${toString cfg.memoryPercent}% RAM, ${cfg.algorithm})";
+      conditions = [
+        "service/syslogd/ready"
+        "task/modprobe/success"
+      ];
       log = true;
       command = pkgs.writeShellScript "zram-swap" ''
         set -eu
@@ -58,10 +65,8 @@ in
             pkgs.util-linux
             pkgs.gnugrep
             pkgs.gawk
-            pkgs.kmod
           ]
         }
-        modprobe zram || true
         grep -q zram /proc/swaps && exit 0
         mem_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
         dev=$(zramctl --find --size "$((mem_kb * ${toString cfg.memoryPercent} / 100))K" --algorithm ${cfg.algorithm})


### PR DESCRIPTION
Adds zram swap as an idempotent finit task (same approach as loadkmap, #170): modprobe, skip if a zram device already swaps, then zramctl/mkswap/swapon. Options: enable, memoryPercent, algorithm, priority — defaults match NixOS's zramSwap. Been running this on two machines since mid-July; kept to the common case, no writeback or multi-device.