### PR TITLE
modules/mango: replace hardcoded wlroots version with reflection

### DIFF
--- a/modules/programs/labwc/default.nix
+++ b/modules/programs/labwc/default.nix
@@ -45,12 +45,17 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.labwc.override {
-        inherit libinput;
-
-        wlroots_0_20 = pkgs.wlroots_0_20.override { inherit libinput; };
-        enableSystemd = false;
-      };
+      default = pkgs.labwc.override (
+        o:
+        let
+          wlrootsAttr = lib.head (lib.filter (lib.hasPrefix "wlroots") (lib.attrNames o));
+        in
+        {
+          inherit libinput;
+          ${wlrootsAttr} = o.${wlrootsAttr}.override { inherit libinput; };
+          enableSystemd = false;
+        }
+      );
       defaultText = lib.literalExpression "pkgs.labwc";
       description = ''
         The package to use for `labwc`.

--- a/modules/programs/mango/default.nix
+++ b/modules/programs/mango/default.nix
@@ -18,6 +18,8 @@ let
     Type=Application
   '';
 
+  mango' = pkgs.mango or pkgs.mangowc;
+
   # gardendevd needs libudev-garden; mdevd/keventd need libudev-zero
   udevApi =
     if config.services.gardendevd.enable then
@@ -50,11 +52,16 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.mango.override {
-        inherit libinput;
-
-        wlroots_0_19 = pkgs.wlroots_0_19.override { inherit libinput; };
-      };
+      default = mango'.override (
+        o:
+        let
+          wlrootsAttr = lib.head (lib.filter (lib.hasPrefix "wlroots") (lib.attrNames o));
+        in
+        {
+          inherit libinput;
+          ${wlrootsAttr} = o.${wlrootsAttr}.override { inherit libinput; };
+        }
+      );
       defaultText = lib.literalExpression "pkgs.mango";
       description = ''
         The package to use for `mango`.

--- a/modules/programs/regreet/default.nix
+++ b/modules/programs/regreet/default.nix
@@ -26,13 +26,6 @@ let
       wacomSupport = false;
     }
   );
-
-  wlroots_0_20 = pkgs.wlroots_0_20.override {
-    inherit libinput;
-
-    # xwayland appears to cause issues - and not required in this context, so no harm in removing
-    enableXWayland = false;
-  };
 in
 {
   imports = with modules; [
@@ -83,9 +76,20 @@ in
     compositor = {
       package = lib.mkOption {
         type = lib.types.package;
-        default = pkgs.cage.override {
-          inherit wlroots_0_20;
-        };
+        default = pkgs.cage.override (
+          o:
+          let
+            wlrootsAttr = lib.head (lib.filter (lib.hasPrefix "wlroots") (lib.attrNames o));
+          in
+          {
+            ${wlrootsAttr} = o.${wlrootsAttr}.override {
+              inherit libinput;
+
+              # xwayland appears to cause issues - and not required in this context, so no harm in removing
+              enableXWayland = false;
+            };
+          }
+        );
         defaultText = lib.literalExpression "pkgs.cage";
         description = ''
           The package to use for `cage`.

--- a/modules/programs/sway/default.nix
+++ b/modules/programs/sway/default.nix
@@ -32,19 +32,19 @@ let
     }
   );
 
-  wlroots_0_20 = pkgs.wlroots_0_20.override {
-    inherit libinput;
+  sway-unwrapped = pkgs.sway-unwrapped.override (
+    o:
+    let
+      wlrootsAttr = lib.head (lib.filter (lib.hasPrefix "wlroots") (lib.attrNames o));
+    in
+    {
+      inherit libinput;
+      ${wlrootsAttr} = o.${wlrootsAttr}.override { inherit libinput; };
 
-    # xwayland appears to cause issues with mdevd - and not required in this context, so no harm in removing
-    enableXWayland = !config.services.mdevd.enable;
-  };
-
-  sway-unwrapped = pkgs.sway-unwrapped.override {
-    inherit libinput wlroots_0_20;
-
-    # since we're recompiling go ahead and disable systemd
-    systemdSupport = udevApi == null;
-  };
+      # since we're recompiling go ahead and disable systemd
+      systemdSupport = udevApi == null;
+    }
+  );
 in
 {
   options.programs.sway = {


### PR DESCRIPTION
Nixpkgs-unstable bumped `mango` version to `0.15.5` last week https://github.com/NixOS/nixpkgs/pull/539969
, and now it use `wlroots_0_20`.
Previously hardcoded wlroots version will cause build failed and need more maintenance. Now it doesn't relay upstream version any more.
I only tested it on my laptop using latest nixpkgs-unstable. But it should also keep backward compatibility when using nixpkgs 26.05 or 25.11 with `mangowc` and `wlrooots_0_19`.