### PR TITLE
programs/limine: fix location for additionalFiles

### DIFF
--- a/modules/programs/limine/limine-install.py
+++ b/modules/programs/limine/limine-install.py
@@ -478,7 +478,7 @@ def install_bootloader() -> None:
     paths[config_file_path] = True
 
     for dest_path, source_path in config('additionalFiles').items():
-        dest_path = os.path.join(limine_install_dir, dest_path)
+        dest_path = os.path.join(str(config('efiMountPoint')), dest_path)
 
         copy_file(source_path, dest_path)
 


### PR DESCRIPTION
Despite the `limine` module description claiming to place files under **/boot**, in practice those were copied to limine's install directory, **/boot/limine**. This caused divergence in bootfiles for apple-silicon users, as boot-m1n1 in **/boot** would never update along with system rebuilds. 
Fixes the aforementioned issue by changing the destination path to the expected location.

Ported from nixpkgs commit
[22ef2ba154e11aec324562a78b0a2656c6d39b72](https://github.com/NixOS/nixpkgs/commit/22ef2ba154e11aec324562a78b0a2656c6d39b72)