### PR TITLE
docs(finit): keep switch-root pre-checks, explain why in the TODO

### DIFF
--- a/modules/finit/initrd.nix
+++ b/modules/finit/initrd.nix
@@ -92,7 +92,9 @@ in
           esac
         done
 
-        # TODO: modify `initctl switch-root` call in finit to have a proper return code
+        # `initctl switch-root` returns a real exit code on failure (finit-project/finit#496)
+        # Keep these checks anyway: they're cheap, catch the common cases before weeven spawn initctl,
+        # and don't depend on finit being patched
         if [ ! -d /sysroot ] || ! mountpoint -q /sysroot || [ ! -x "/sysroot$stage2Init" ]; then
           cat > /dev/console <<EOF
 


### PR DESCRIPTION
That fix means `initctl switch-root` will eventually return a real exit code and error message on failure instead of lying about success

Depends on: finit-project/finit#496