### PR TITLE
feat: add services.nix-daemon.registry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,11 @@
           config = lib.evalModules {
             class = "nixos";
             specialArgs = lib.recursiveUpdate { modules = self.nixosModules; } specialArgs;
-            modules = [ self.nixosModules.default ] ++ modules;
+            modules = [
+              self.nixosModules.default
+              ({pkgs,...}:{ services.nix-daemon.flake.source = toString pkgs.path; })
+            ]
+            ++ modules;
           };
         in
         config

--- a/modules/services/nix-daemon/default.nix
+++ b/modules/services/nix-daemon/default.nix
@@ -63,8 +63,13 @@ let
       ${mkKeyValuePairs (lib.filterAttrs (key: value: !(isExtra key)) cfg.settings)}
       ${mkKeyValuePairs (lib.filterAttrs (key: value: isExtra key) cfg.settings)}
     '';
+
+    flakeRefFormat = ''
+      The format of flake references is described in {manpage}`nix3-flake(1)`.
+    '';
 in
 {
+  imports = [ ./nix-flake.nix ];
   options.services.nix-daemon = {
     enable = lib.mkOption {
       type = lib.types.bool;
@@ -95,6 +100,92 @@ in
         perform secure concurrent builds.  If you receive an error
         message saying that "all build users are currently in use",
         you should increase this value.
+      '';
+    };
+
+    registry = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          let
+            referenceAttrs =
+              with lib.types;
+              attrsOf (oneOf [
+                str
+                int
+                bool
+                path
+                package
+              ]);
+          in
+          { config, name, ... }:
+          {
+            options = {
+              from = lib.mkOption {
+                type = referenceAttrs;
+                example = {
+                  type = "indirect";
+                  id = "nixpkgs";
+                };
+                description = ''
+                  The flake reference to be rewritten.
+
+                  ${flakeRefFormat}
+                '';
+              };
+              to = lib.mkOption {
+                type = referenceAttrs;
+                example = {
+                  type = "github";
+                  owner = "my-org";
+                  repo = "my-nixpkgs";
+                };
+                description = ''
+                  The flake reference {option}`from` is rewritten to.
+
+                  ${flakeRefFormat}
+                '';
+              };
+              flake = lib.mkOption {
+                type = lib.types.nullOr lib.types.attrs;
+                default = null;
+                example = lib.literalExpression "nixpkgs";
+                description = ''
+                  The flake input {option}`from` is rewritten to.
+                '';
+              };
+              exact = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = ''
+                  Whether the {option}`from` reference needs to match exactly. If set,
+                  a {option}`from` reference like `nixpkgs` does not
+                  match with a reference like `nixpkgs/nixos-20.03`.
+                '';
+              };
+            };
+            config = {
+              from = lib.mkDefault {
+                type = "indirect";
+                id = name;
+              };
+              to = lib.mkIf (config.flake != null) (
+                lib.mkDefault (
+                  {
+                    type = "path";
+                    path = config.flake.outPath;
+                  }
+                  // lib.filterAttrs (n: _: n == "lastModified" || n == "rev" || n == "narHash") config.flake
+                )
+              );
+            };
+          }
+        )
+      );
+      default = { };
+      description = ''
+        A system-wide flake registry.
+
+        See {manpage}`nix3-registry(1)` for more information.
       '';
     };
 
@@ -344,5 +435,10 @@ in
       # standard nixos trick to force a restart when something has changed
       # ${config.environment.etc."nix/nix.conf".source}
     '';
+
+    environment.etc."nix/registry.json".text = builtins.toJSON {
+      version = 2;
+      flakes = lib.mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
+    };
   };
 }

--- a/modules/services/nix-daemon/nix-flake.nix
+++ b/modules/services/nix-daemon/nix-flake.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.services.nix-daemon.flake;
+in {
+  options.services.nix-daemon.flake = {
+    source = lib.mkOption {
+      # In newer Nix versions, particularly with lazy trees, outPath of
+      # flakes becomes a Nix-language path object. We deliberately allow this
+      # to gracefully come through the interface in discussion with @roberth.
+      #
+      # See: https://github.com/NixOS/nixpkgs/pull/278522#discussion_r1460292639
+      type = lib.types.nullOr (lib.types.either lib.types.str lib.types.path);
+
+      default = null;
+      defaultText = "if (using finix.lib.finixSystem) then toString pkgs.path else null";
+
+      example = ''fetchTarball { name = "source"; sha256 = "${lib.fakeHash}"; url = "https://github.com/nixos/nixpkgs/archive/somecommit.tar.gz"; }'';
+
+      description = ''
+        The path to the nixpkgs instance used to build the system. This is automatically set up to be
+        the store path of the nixpkgs instance (nixpkgs.pkgs) used to build the system if using
+        `finix.lib.finixSystem`, and is otherwise null by default.
+
+        This can also be optionally set if the finix system is not built with a flake but still uses
+        pinned sources: set this to the store path for the nixpkgs sources used to build the system,
+        as may be obtained by `fetchTarball`, for example.
+
+        Note: the name of the store path must be "source" due to
+        <https://github.com/NixOS/nix/issues/7075>.
+      '';
+    };
+
+    setNixPath = lib.mkOption {
+      type = lib.types.bool;
+
+      default = cfg.source != null;
+      defaultText = "config.nixpkgs.flake.source != null";
+
+      description = ''
+        Whether to set {env}`NIX_PATH` to include `nixpkgs=flake:nixpkgs` such that `<nixpkgs>`
+        lookups receive the version of nixpkgs that the system was built with, in concert with
+        {option}`nixpkgs.flake.setFlakeRegistry`.
+
+        This is on by default for finix configurations built with flakes.
+
+        This makes {command}`nix-build '<nixpkgs>' -A hello` work out of the box on flake systems.
+
+        Note that this option makes the finix closure depend on the nixpkgs sources, which may add
+        undesired closure size if the system will not have any nix commands run on it.
+      '';
+    };
+
+    setFlakeRegistry = lib.mkOption {
+      type = lib.types.bool;
+
+      default = cfg.source != null;
+      defaultText = "config.nixpkgs.flake.source != null";
+
+      description = ''
+        Whether to pin nixpkgs in the system-wide flake registry (`/etc/nix/registry.json`) to the
+        store path of the sources of nixpkgs used to build the finix system.
+
+        This is on by default for finix configurations built with flakes.
+
+        This option makes {command}`nix run nixpkgs#hello` reuse dependencies from the system, avoid
+        refetching nixpkgs, and have a consistent result every time.
+
+        Note that this option makes the finix closure depend on the nixpkgs sources, which may add
+        undesired closure size if the system will not have any nix commands run on it.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.source != null) (
+     lib.mkMerge [
+       {
+         assertions = [
+           {
+             assertion = cfg.setNixPath -> cfg.setFlakeRegistry;
+             message = ''
+               Setting `nixpkgs.flake.setNixPath` requires that `nixpkgs.flake.setFlakeRegistry` also
+               be set, since it is implemented in terms of indirection through the flake registry.
+             '';
+           }
+         ];
+       }
+       (lib.mkIf cfg.setFlakeRegistry {
+         services.nix-daemon.registry.nixpkgs.to = lib.mkDefault {
+           type = "path";
+           path = cfg.source;
+         };
+       })
+       (lib.mkIf cfg.setNixPath {
+         # TODO finix doesnt have a NIX_PATH option yet
+         # services.nix-daemon.nixPath = lib.mkDefault (
+         #   [ "nixpkgs=flake:nixpkgs" ]
+         #   ++ lib.optional config.nix.channel.enable "/nix/var/nix/profiles/per-user/root/channels"
+         # );
+       })
+     ]
+   );
+}


### PR DESCRIPTION
This option writes /etc/nix/registry.json, i copied the logic from the nixos module. It is worth noting that it is reccomended to set
```nix
  {nixpkgs, finix, ...}: {
      nixosConfigurations.finixos = finix.lib.finixSystem {
        modules = with finix.nixosModules; [
          {
            nixpkgs.pkgs = ...;
  
            services.nix-daemon.registry.nixpkgs.to =  {
              type = "path";
              path = nixpkgs.outPath; # or `toString pkgs.path` for legacy systems or to move out of flake.nix
            };
          }
  };
```
in outputs for compatibility with legacy projects and nix repl.

This should be added to examples or set by default (using `nixpkgs.pkgs?`), although the former would fit more with finix.

I have roughly tested this like so: I build nixosConfigurations.finix.config.system.build.toplevel in a modified examples/installations/flakes/minimal with the code above, and from the `activate` file I found the related etc path, where `/nix/registry.json` is:
```json
{"flakes":[{"exact":true,"from":{"id":"nixpkgs","type":"indirect"},"to":{"path":"/nix/store/1dffznc7fgw6xnzssy1h4waxz63i11qa-source","type":"path"}}],"version":2}
```
This is my registry on my nixos system: 
```json
{"flakes":[{"exact":true,"from":{"id":"nixpkgs","type":"indirect"},"to":{"path":"/nix/store/lj0fr41wwbrx2mwq2378jg8qrns7b93d-source","type":"path"}}],"version":2}
```
Its fair to assume this will work just fine.