### PR TITLE
modules/mdev: init

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -25,6 +25,7 @@ let
       "gardendevd"
       "keventd"
       "mdevd"
+      "mdev"
       "seatd"
       "udev"
     ]
@@ -59,6 +60,7 @@ in
       ./services/elogind
       ./services/gardendevd
       ./services/keventd
+      ./services/mdev
       ./services/mdevd
       ./services/seatd
       ./services/udev

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -24,6 +24,7 @@ let
       "gardendevd"
       "keventd"
       "mdevd"
+      "mdev"
       "seatd"
       "udev"
     ]
@@ -57,6 +58,7 @@ in
       ./services/elogind
       ./services/gardendevd
       ./services/keventd
+      ./services/mdev
       ./services/mdevd
       ./services/seatd
       ./services/udev

--- a/modules/finit/initrd.nix
+++ b/modules/finit/initrd.nix
@@ -8,6 +8,47 @@ let
   cfg = config.boot.initrd;
 
   grantAccess = cfg.emergencyAccess == true || lib.isString cfg.emergencyAccess;
+
+  fsPackages = lib.unique (
+    lib.flatten (
+      lib.concatMap (v: lib.optional v.enable v.packages or [ ]) (
+        lib.attrValues config.boot.initrd.supportedFilesystems
+      )
+    )
+  );
+
+  path = pkgs.buildEnv {
+    name = "initrd-path";
+    paths = [
+      pkgs.busybox
+      pkgs.kmod
+      (lib.hiPrio pkgs.util-linux.mount)
+      pkgs.bash
+      config.finit.package
+    ]
+    ++ lib.optionals config.services.mdevd.enable [
+      config.services.mdevd.package
+      pkgs.execline
+      pkgs.util-linux
+    ]
+    ++ lib.optionals config.services.gardendevd.enable [
+      config.services.gardendevd.package
+      pkgs.util-linux
+    ]
+    ++ lib.optionals config.services.udev.enable [ config.services.udev.package ]
+    ++ lib.optionals config.services.mdev.enable [ pkgs.util-linux ]
+    ++ fsPackages;
+    pathsToLink = [
+      "/bin"
+    ];
+
+    ignoreCollisions = true;
+
+    postBuild = ''
+      # Remove wrapped binaries, they shouldn't be accessible via PATH.
+      find $out/bin -maxdepth 1 -name ".*-wrapped" -type l -delete
+    '';
+  };
 in
 {
   options.boot.initrd = {

--- a/modules/finit/initrd.nix
+++ b/modules/finit/initrd.nix
@@ -36,6 +36,7 @@ let
       pkgs.util-linux
     ]
     ++ lib.optionals config.services.udev.enable [ config.services.udev.package ]
+    ++ lib.optionals config.services.mdev.enable [ pkgs.util-linux ]
     ++ fsPackages;
     pathsToLink = [
       "/bin"

--- a/modules/finit/mount.nix
+++ b/modules/finit/mount.nix
@@ -63,6 +63,7 @@ let
 
   deviceConditions =
     lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
+    ++ lib.optionals config.services.mdev.enable [ "run/coldplug/success" ]
     ++ lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
     ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
     ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ];

--- a/modules/programs/xorg/default.nix
+++ b/modules/programs/xorg/default.nix
@@ -12,7 +12,7 @@ let
   udevApi =
     if config.services.gardendevd.enable then
       pkgs.libudev-garden
-    else if config.services.mdevd.enable || config.services.keventd.enable then
+    else if config.services.mdevd.enable || config.services.mdev.enable || config.services.keventd.enable then
       pkgs.libudev-zero
     else
       null;

--- a/modules/programs/xorg/default.nix
+++ b/modules/programs/xorg/default.nix
@@ -12,7 +12,9 @@ let
   udevApi =
     if config.services.gardendevd.enable then
       pkgs.libudev-garden
-    else if config.services.mdevd.enable || config.services.mdev.enable || config.services.keventd.enable then
+    else if
+      config.services.mdevd.enable || config.services.mdev.enable || config.services.keventd.enable
+    then
       pkgs.libudev-zero
     else
       null;

--- a/modules/services/gardendevd/default.nix
+++ b/modules/services/gardendevd/default.nix
@@ -199,7 +199,7 @@ in
     # build out the default initramfs image
     boot.initrd = {
       path = [
-        config.service.gardendevd.package
+        config.services.gardendevd.package
       ];
 
       finit.services.gardendevd = {

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -237,6 +237,22 @@ in
         Mdeved rules for coldplug events during the initramfs stage of booting.
       '';
     };
+
+    useDaemon = mkOption {
+      type = types.bool;
+      description = ''
+        `mdev` can be invoked in 2 ways. The first is to not 
+        daemonise, and instead use the legacy /proc/sys/kernel/hotplug
+        file to handle hotplugging by the mechanism of the kernel
+        forking `mdev` every time a uevent comes thorugh. This will 
+        likely require recompiling the kernel.
+
+        The second way is to use the `mdev -d` command, introduced
+        in busybox 1.31.0, allows the `mdev` process to run as a
+        system service. This does not require recompiling the kernel
+        and is recommended for most users.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -259,14 +275,6 @@ in
 
     environment.etc."mdev.conf".text = config.services.mdev.hotplugRules;
 
-    finit.tasks.register-hotplug = {
-      description = "Registering kernel hotplug";
-      command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
-      runlevels = "S";
-      cgroup.name = "init";
-      log = true;
-    };
-
     # We need(?) this to be blocking so that everything is loaded before coldplug.
     # Crucially, colplugging mdev does *not* trigger our modalias rule
     #
@@ -284,14 +292,6 @@ in
       log = true;
     };
 
-    finit.tasks.coldplug = {
-      description = "Cold plugging system";
-      command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
-      runlevels = "S";
-      conditions = "run/modalias-load/success";
-      cgroup.name = "init";
-      log = true;
-    };
 
     system.activation.scripts.mdev = lib.mkIf config.boot.kernel.enable {
       text = ''
@@ -304,33 +304,14 @@ in
 
     system.switch.inhibitors.device-manager = "mdev";
 
-    boot.kernelPatches = [
-      {
-        name = "uevent-helper";
-        patch = null;
-        structuredExtraConfig = {
-          UEVENT_HELPER = lib.mkForce lib.kernel.yes;
-        };
-      }
-    ];
-
     # build out the default initramfs image
     boot.initrd = {
-      finit.run.register-hotplug = {
-        command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
-        priority = 200;
-      };
 
       # TODO: always reports as fail, maybe wrap it as seen in the comment?
       finit.run.modalias-load = {
         # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
         command = "find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q";
         priority = 210;
-      };
-
-      finit.run.coldplug = {
-        command = "mdev -s";
-        priority = 220;
       };
 
       contents = [
@@ -344,5 +325,68 @@ in
         }
       ];
     };
+  } // mkIf cfg.useDaemon {
+    finit.services.mdev = {
+      description = "device event daemon (mdev)";
+      command = "${cfg.package}/bin/busybox mdev -df -S"
+        + lib.optionalString cfg.debug " -v";
+      runlevels = "S12345789";
+      cgroup.name = "init";
+      notify = "pid";
+      log = true;
+
+      # TODO: now we're hijacking `env` and no one else can use it...
+      path = [
+        config.programs.coreutils.package
+        pkgs.util-linux
+      ];
+    };
+
+    boot.initrd = {
+      finit.services.mdevd = {
+      description = "device event daemon (mdevd)";
+      command = "mdev -df";
+      notify = "pid";
+      };
+    };
+  } // mkIf (!cfg.useDaemon) {
+    finit.tasks.register-hotplug = {
+      description = "Registering kernel hotplug";
+      command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+      runlevels = "S";
+      cgroup.name = "init";
+      log = true;
+    };
+
+    finit.tasks.coldplug = {
+      description = "Cold plugging system";
+      command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
+      runlevels = "S";
+      conditions = "run/modalias-load/success";
+      cgroup.name = "init";
+      log = true;
+    };
+
+    boot.initrd = {
+      finit.run.register-hotplug = {
+        command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+        priority = 200;
+      };
+
+      finit.run.coldplug = {
+        command = "mdev -s";
+        priority = 220;
+      };
+    };
+
+    boot.kernelPatches = [
+      {
+        name = "uevent-helper";
+        patch = null;
+        structuredExtraConfig = {
+          UEVENT_HELPER = lib.mkForce lib.kernel.yes;
+        };
+      }
+    ];
   };
 }

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -288,7 +288,7 @@ in
         exit 0
       ''}";
       runlevels = "S";
-      conditions = "task/register-hotplug/success";
+      conditions = lib.mkIf (!cfg.useDaemon) "task/register-hotplug/success";
       cgroup.name = "init";
       log = true;
     };
@@ -332,6 +332,7 @@ in
       command = "${cfg.package}/bin/busybox mdev -df -S"
         + lib.optionalString cfg.debug " -v";
       runlevels = "S12345789";
+      conditions = "run/modalias-load/success";
       cgroup.name = "init";
       notify = "pid";
       log = true;
@@ -345,9 +346,9 @@ in
 
     boot.initrd = {
       finit.services.mdevd = {
-      description = "device event daemon (mdevd)";
-      command = "mdev -df";
-      notify = "pid";
+        description = "device event daemon (mdevd)";
+        command = "mdev -df";
+        notify = "pid";
       };
     };
   } // mkIf (!cfg.useDaemon) {

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -324,6 +324,7 @@ in
     }
 
     (mkIf cfg.useDaemon {
+      /*
       finit.tasks.coldplug = {
         description = "Cold plugging system";
         command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
@@ -332,13 +333,14 @@ in
         cgroup.name = "init";
         log = true;
       };
+      */
 
       finit.services.mdev = {
         description = "device event daemon (mdev)";
         command = "${cfg.package}/bin/busybox mdev -df -S"
           + lib.optionalString cfg.debug " -v";
         runlevels = "S12345789";
-        conditions = "task/coldplug/success";
+        conditions = "run/modalias-load/success";
         cgroup.name = "init";
         notify = "pid";
         log = true;
@@ -350,10 +352,12 @@ in
         ];
       };
       
+      /*
       boot.initrd.finit.run.coldplug = {
         command = "mdev -s";
         priority = 220;
       };
+      */
 
       boot.initrd.finit.services.mdev = {
         description = "device event daemon (mdev)";

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -306,26 +306,23 @@ in
     system.switch.inhibitors.device-manager = "mdev";
 
     # build out the default initramfs image
-    boot.initrd = {
-
-      # TODO: always reports as fail, maybe wrap it as seen in the comment?
-      finit.run.modalias-load = {
-        # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
-        command = "find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q";
-        priority = 210;
-      };
-
-      contents = [
-        {
-          target = "/etc/mdev.conf";
-          source = pkgs.writeText "mdev.conf" config.services.mdev.coldplugRules;
-        }
-        {
-          source = devDiskScript;
-          target = "/etc/mdev-disk.sh";
-        }
-      ];
+    # TODO: always reports as fail, maybe wrap it as seen in the comment?
+    boot.initrd.finit.run.modalias-load = {
+      # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
+      command = "find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q";
+      priority = 210;
     };
+
+    boot.initrd.contents = [
+      {
+        target = "/etc/mdev.conf";
+        source = pkgs.writeText "mdev.conf" config.services.mdev.coldplugRules;
+      }
+      {
+        source = devDiskScript;
+        target = "/etc/mdev-disk.sh";
+      }
+    ];
   } // mkIf cfg.useDaemon {
     finit.services.mdev = {
       description = "device event daemon (mdev)";

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -240,6 +240,7 @@ in
 
     useDaemon = mkOption {
       type = types.bool;
+      default = true;
       description = ''
         `mdev` can be invoked in 2 ways. The first is to not 
         daemonise, and instead use the legacy /proc/sys/kernel/hotplug

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -335,12 +335,10 @@ in
         log = true;
 
         # TODO: now we're hijacking `env` and no one else can use it...
-        /*
         path = [
           config.programs.coreutils.package
           pkgs.util-linux
         ];
-        */
       };
       
       boot.initrd.finit.run.coldplug = {

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -311,6 +311,12 @@ in
         priority = 210;
       };
 
+      boot.initrd.path = [
+        config.services.mdev.package
+        config.programs.coreutils.package
+        pkgs.util-linux
+      ];
+
       boot.initrd.contents = [
         {
           target = "/etc/mdev.conf";

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -324,12 +324,21 @@ in
     }
 
     (mkIf cfg.useDaemon {
+      finit.tasks.coldplug = {
+        description = "Cold plugging system";
+        command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
+        runlevels = "S";
+        conditions = "run/modalias-load/success";
+        cgroup.name = "init";
+        log = true;
+      };
+
       finit.services.mdev = {
         description = "device event daemon (mdev)";
         command = "${cfg.package}/bin/busybox mdev -df -S"
           + lib.optionalString cfg.debug " -v";
         runlevels = "S12345789";
-        conditions = "run/modalias-load/success";
+        conditions = "task/coldplug/success";
         cgroup.name = "init";
         notify = "pid";
         log = true;

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -1,0 +1,350 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    ;
+
+  gidOf = name: toString config.ids.gids.${name};
+
+  cfg = config.services.mdev;
+
+  # Rules for the special standalone devices to be created at boot.
+  specialRules =
+    let
+      tty = gidOf "tty";
+      input = gidOf "input";
+    in
+    ''
+      null         0:0 666
+      zero         0:0 666
+      full         0:0 666
+      random       0:0 444
+      urandom      0:0 444
+      hwrandom     0:0 444
+
+      ptmx         0:${tty}           666
+      pty.*        0:${tty}           660
+      tty          0:${tty}           666
+      tty[0-9]+    0:${tty}           660
+
+      vcsa[0-9]*   0:${tty}           660
+      ttyS[0-9]*   0:${gidOf "uucp"}  660
+
+      snd/.*       0:${gidOf "audio"} 660         @${libudev-zero-helper}/bin/helper
+      dri/.*       0:${gidOf "video"} 660
+
+      video[0-9]+  0:${gidOf "video"} 660         @${libudev-zero-helper}/bin/helper
+      input/.*     0:${input}         660         @${libudev-zero-helper}/bin/helper
+
+      event[0-9]+  0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
+      mouse[0-9]+  0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
+      js[0-9]+     0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
+      mice         0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
+   '';
+
+  # Insert modules for devices with a modalias.
+  modaliasRule = ''-$MODALIAS=.* 0:0 660 @${pkgs.kmod}/bin/modprobe --quiet "$MODALIAS"'';
+
+  # https://github.com/illiliti/libudev-zero/blob/master/contrib/helper.c
+  libudev-zero-helper = pkgs.writeCBin "helper" ''
+    /*
+     * Copyright (c) 2020-2021 illiliti <illiliti@protonmail.com>
+     * SPDX-License-Identifier: ISC
+     * 
+     * Permission to use, copy, modify, and/or distribute this software for any
+     * purpose with or without fee is hereby granted, provided that the above
+     * copyright notice and this permission notice appear in all copies.
+     * 
+     * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+     * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+     * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+     * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+     * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+     * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+     * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+     *
+     *
+     * Construct uevent message from environment and send it to 0x4 netlink group.
+     */
+
+    #include <stdio.h>
+    #include <string.h>
+    #include <unistd.h>
+    #include <sys/socket.h>
+    #include <linux/netlink.h>
+
+    int main(int argc, char **argv)
+    {
+        struct sockaddr_nl sa = {0};
+        struct msghdr hdr = {0};
+        struct iovec iov = {0};
+        extern char **environ;
+        char buf[8192];
+        size_t len;
+        int i, fd;
+
+        iov.iov_base = buf;
+        iov.iov_len = 0;
+
+        for (i = 0; environ[i]; i++) {
+            if (strncmp(environ[i], "PATH=", 5) == 0 ||
+                strncmp(environ[i], "HOME=", 5) == 0) {
+                continue;
+            }
+
+            len = strlen(environ[i]) + 1;
+
+            if (iov.iov_len + len > sizeof(buf)) {
+                fprintf(stderr, "%s: uevent exceeds buffer size", argv[0]);
+                return 1;
+            }
+
+            memcpy(buf + iov.iov_len, environ[i], len);
+            iov.iov_len += len;
+        }
+
+        sa.nl_family = AF_NETLINK;
+        sa.nl_groups = 0x4; // XXX
+
+        hdr.msg_name = &sa;
+        hdr.msg_namelen = sizeof(sa);
+        hdr.msg_iov = &iov;
+        hdr.msg_iovlen = 1;
+
+        fd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);
+
+        if (fd == -1) {
+            perror("socket");
+            return 1;
+        }
+
+        if (sendmsg(fd, &hdr, 0) == -1) {
+            perror("sendmsg");
+            close(fd);
+            return 1;
+        }
+
+        close(fd);
+        return 0;
+    }
+  '';
+
+  # We need symlinks in /dev/disk/{by-id,by-label,by-uuid,by-partlabel,by-partuuid}
+  # so we run this script for block device events.
+  # Requires blkid from util-linux be on $PATH.
+  #
+  # Note: The by-id symlinks just use the device name as a placeholder.
+  # Real unique IDs would require querying device serial numbers, etc.
+  devDiskScript = pkgs.writeScript "mdev-disk.sh" ''
+    #!/bin/sh
+    case "$ACTION" in
+      add)
+        # Create by-id symlink (using device name as placeholder ID)
+        mkdir -p /dev/disk/by-id
+        ln -sf "../../$MDEV" "/dev/disk/by-id/$MDEV"
+
+        # Create by-label, by-uuid, by-partlabel and by-partuuid symlinks from blkid output
+        blkid --output export "/dev/$MDEV" 2>/dev/null | while IFS='=' read -r key value; do
+          case "$key" in
+            LABEL)
+              mkdir -p /dev/disk/by-label
+              ln -sf "../../$MDEV" "/dev/disk/by-label/$value"
+              ;;
+            UUID)
+              mkdir -p /dev/disk/by-uuid
+              ln -sf "../../$MDEV" "/dev/disk/by-uuid/$value"
+              ;;
+            PARTLABEL)
+              mkdir -p /dev/disk/by-partlabel
+              ln -sf "../../$MDEV" "/dev/disk/by-partlabel/$value"
+              ;;
+            PARTUUID)
+              mkdir -p /dev/disk/by-partuuid
+              ln -sf "../../$MDEV" "/dev/disk/by-partuuid/$value"
+              ;;
+          esac
+        done
+        ;;
+      remove) # Remove symlinks pointing to this device.
+        # We scan directories instead of calling blkid since the device may already be gone.
+        for dir in /dev/disk/by-id /dev/disk/by-label /dev/disk/by-uuid /dev/disk/by-partlabel /dev/disk/by-partuuid; do
+          [ -d "$dir" ] || continue
+          for link in "$dir"/*; do
+            [ -L "$link" ] || continue
+            target=$(readlink "$link")
+            case "$target" in
+              "../../$MDEV") rm -f "$link" ;;
+            esac
+          done
+        done
+        ;;
+    esac
+  '';
+
+  # Use * prefix to run via /bin/sh on any action (add/remove).
+  devDiskRule = ''
+    [hs]d[a-z][0-9]* 0:${gidOf "disk"} 660 *${devDiskScript}
+    nvme[0-9]n[0-9]*p[0-9]* 0:${gidOf "disk"} 660 *${devDiskScript}
+  '';
+in
+{
+  options.services.mdev = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable [mdev](${pkgs.busybox.meta.homepage}) as a system service.
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.busybox;
+      defaultText = lib.literalExpression "pkgs.busybox";
+      description = ''
+        The package to use for `mdev`.
+      '';
+    };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable debug logging.
+      '';
+    };
+
+    hotplugRules = mkOption {
+      type = types.lines;
+      description = ''
+        Mdevd rules for hotplug events.
+        These rules are active after the initial `mdevd` daemon
+        has coldbooted with the `services.mdevd.coldplug` rules.
+      '';
+    };
+
+    coldplugRules = mkOption {
+      type = types.lines;
+      description = ''
+        Mdeved rules for coldplug events during the initramfs stage of booting.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    # Populate with boot rules.
+    services.mdev = {
+      hotplugRules = lib.mkMerge [
+        # fallthrough rules at the top
+        (lib.mkOrder 250 modaliasRule)
+        (lib.mkBefore devDiskRule)
+        specialRules
+
+      ];
+      coldplugRules = lib.concatLines [
+        modaliasRule
+        specialRules
+        devDiskRule
+      ];
+    };
+
+    environment.etc."mdev.conf".text = config.services.mdev.hotplugRules;
+
+    finit.tasks.register-hotplug = {
+      description = "Registering kernel hotplug";
+      command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+      runlevels = "S";
+      cgroup.name = "init";
+      log = true;
+    };
+
+    # We need(?) this to be blocking so that everything is loaded before coldplug.
+    # Crucially, colplugging mdev does *not* trigger our modalias rule
+    #
+    # https://lists.busybox.net/pipermail/busybox/2014-September/081780.html
+    finit.run.modalias-load = {
+      description = "Load modules for coldplugged devices";
+      command = "${pkgs.writeShellScript "modalias-load" ''
+        aliases=$(find /sys/devices -name modalias -type f | xargs -r cat | sort -u)
+        echo "$aliases" | xargs -r -P"$(nproc)" -n1 ${pkgs.kmod}/bin/modprobe -q
+        exit 0
+      ''}";
+      runlevels = "S";
+      conditions = "task/register-hotplug/success";
+      cgroup.name = "init";
+      log = true;
+    };
+
+    finit.tasks.coldplug = {
+      description = "Cold plugging system";
+      command =
+        "${cfg.package}/bin/busybox mdev -s"
+        + lib.optionalString cfg.debug " -v";
+      runlevels = "S";
+      conditions = "run/modalias-load/success";
+      cgroup.name = "init";
+      log = true;
+    };
+
+    system.activation.scripts.mdev = lib.mkIf config.boot.kernel.enable {
+      text = ''
+        # Allow the kernel to find our firmware.
+        if [ -e /sys/module/firmware_class/parameters/path ]; then
+          echo -n "${config.hardware.firmware}/lib/firmware" > /sys/module/firmware_class/parameters/path
+        fi
+      '';
+    };
+
+    system.switch.inhibitors.device-manager = "mdev";
+
+    boot.kernelPatches = [
+      {
+        name = "uevent-helper";
+        patch = null;
+        structuredExtraConfig = {
+          UEVENT_HELPER = lib.mkForce lib.kernel.yes;
+        };
+      }
+    ];
+
+    # build out the default initramfs image
+    boot.initrd = {
+      finit.run.register-hotplug = {
+        command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+        priority = 200;
+      };
+
+      # TODO: always reports as fail, maybe wrap it as seen in the comment?
+      finit.run.modalias-load = {
+        # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
+        command = "find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q";
+        priority = 210;
+      };
+
+      finit.run.coldplug = {
+        command = "mdev -s";
+        priority = 220;
+      };
+
+      contents = [
+        {
+          target = "/etc/mdev.conf";
+          source = pkgs.writeText "mdev.conf" config.services.mdev.coldplugRules;
+        }
+        {
+          source = devDiskScript;
+          target = "/etc/mdev-disk.sh";
+        }
+      ];
+    };
+  };
+}

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -358,12 +358,10 @@ in
         ];
       };
       
-      /*
       boot.initrd.finit.run.coldplug = {
         command = "mdev -s";
         priority = 220;
       };
-      */
 
       boot.initrd.finit.services.mdev = {
         description = "device event daemon (mdev)";

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -256,132 +256,137 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf cfg.enable (lib.mkMerge [
+    {
+      # Populate with boot rules.
+      services.mdev = {
+        hotplugRules = lib.mkMerge [
+          # fallthrough rules at the top
+          (lib.mkOrder 250 modaliasRule)
+          (lib.mkBefore devDiskRule)
+          specialRules
 
-    # Populate with boot rules.
-    services.mdev = {
-      hotplugRules = lib.mkMerge [
-        # fallthrough rules at the top
-        (lib.mkOrder 250 modaliasRule)
-        (lib.mkBefore devDiskRule)
-        specialRules
+        ];
+        coldplugRules = lib.concatLines [
+          modaliasRule
+          specialRules
+          devDiskRule
+        ];
+      };
 
+      environment.etc."mdev.conf".text = config.services.mdev.hotplugRules;
+
+      # We need(?) this to be blocking so that everything is loaded before coldplug.
+      # Crucially, colplugging mdev does *not* trigger our modalias rule
+      #
+      # https://lists.busybox.net/pipermail/busybox/2014-September/081780.html
+      finit.run.modalias-load = {
+        description = "Load modules for coldplugged devices";
+        command = "${pkgs.writeShellScript "modalias-load" ''
+          aliases=$(find /sys/devices -name modalias -type f | xargs -r cat | sort -u)
+          echo "$aliases" | xargs -r -P"$(nproc)" -n1 ${pkgs.kmod}/bin/modprobe -q
+          exit 0
+        ''}";
+        runlevels = "S";
+        conditions = lib.mkIf (!cfg.useDaemon) "task/register-hotplug/success";
+        cgroup.name = "init";
+        log = true;
+      };
+
+
+      system.activation.scripts.mdev = lib.mkIf config.boot.kernel.enable {
+        text = ''
+          # Allow the kernel to find our firmware.
+          if [ -e /sys/module/firmware_class/parameters/path ]; then
+            echo -n "${config.hardware.firmware}/lib/firmware" > /sys/module/firmware_class/parameters/path
+          fi
+        '';
+      };
+
+      system.switch.inhibitors.device-manager = "mdev";
+
+      # build out the default initramfs image
+      # TODO: always reports as fail, maybe wrap it as seen in the comment?
+      boot.initrd.finit.run.modalias-load = {
+        # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
+        command = "find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q";
+        priority = 210;
+      };
+
+      boot.initrd.contents = [
+        {
+          target = "/etc/mdev.conf";
+          source = pkgs.writeText "mdev.conf" config.services.mdev.coldplugRules;
+        }
+        {
+          source = devDiskScript;
+          target = "/etc/mdev-disk.sh";
+        }
       ];
-      coldplugRules = lib.concatLines [
-        modaliasRule
-        specialRules
-        devDiskRule
+    }
+
+    (mkIf cfg.useDaemon {
+      finit.services.mdev = {
+        description = "device event daemon (mdev)";
+        command = "${cfg.package}/bin/busybox mdev -df -S"
+          + lib.optionalString cfg.debug " -v";
+        runlevels = "S12345789";
+        conditions = "run/modalias-load/success";
+        cgroup.name = "init";
+        notify = "pid";
+        log = true;
+
+        # TODO: now we're hijacking `env` and no one else can use it...
+        path = [
+          config.programs.coreutils.package
+          pkgs.util-linux
+        ];
+      };
+
+      boot.initrd.finit.services.mdevd = {
+        description = "device event daemon (mdevd)";
+        command = "mdev -df";
+        notify = "pid";
+      };
+    })
+
+    (mkIf (!cfg.useDaemon) {
+      finit.tasks.register-hotplug = {
+        description = "Registering kernel hotplug";
+        command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+        runlevels = "S";
+        cgroup.name = "init";
+        log = true;
+      };
+
+      finit.tasks.coldplug = {
+        description = "Cold plugging system";
+        command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
+        runlevels = "S";
+        conditions = "run/modalias-load/success";
+        cgroup.name = "init";
+        log = true;
+      };
+
+      boot.initrd.finit.run.register-hotplug = {
+        command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+        priority = 200;
+      };
+
+      boot.initrd.finit.run.coldplug = {
+        command = "mdev -s";
+        priority = 220;
+      };
+
+      boot.kernelPatches = [
+        {
+          name = "uevent-helper";
+          patch = null;
+          structuredExtraConfig = {
+            UEVENT_HELPER = lib.mkForce lib.kernel.yes;
+          };
+        }
       ];
-    };
-
-    environment.etc."mdev.conf".text = config.services.mdev.hotplugRules;
-
-    # We need(?) this to be blocking so that everything is loaded before coldplug.
-    # Crucially, colplugging mdev does *not* trigger our modalias rule
-    #
-    # https://lists.busybox.net/pipermail/busybox/2014-September/081780.html
-    finit.run.modalias-load = {
-      description = "Load modules for coldplugged devices";
-      command = "${pkgs.writeShellScript "modalias-load" ''
-        aliases=$(find /sys/devices -name modalias -type f | xargs -r cat | sort -u)
-        echo "$aliases" | xargs -r -P"$(nproc)" -n1 ${pkgs.kmod}/bin/modprobe -q
-        exit 0
-      ''}";
-      runlevels = "S";
-      conditions = lib.mkIf (!cfg.useDaemon) "task/register-hotplug/success";
-      cgroup.name = "init";
-      log = true;
-    };
-
-
-    system.activation.scripts.mdev = lib.mkIf config.boot.kernel.enable {
-      text = ''
-        # Allow the kernel to find our firmware.
-        if [ -e /sys/module/firmware_class/parameters/path ]; then
-          echo -n "${config.hardware.firmware}/lib/firmware" > /sys/module/firmware_class/parameters/path
-        fi
-      '';
-    };
-
-    system.switch.inhibitors.device-manager = "mdev";
-
-    # build out the default initramfs image
-    # TODO: always reports as fail, maybe wrap it as seen in the comment?
-    boot.initrd.finit.run.modalias-load = {
-      # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
-      command = "find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q";
-      priority = 210;
-    };
-
-    boot.initrd.contents = [
-      {
-        target = "/etc/mdev.conf";
-        source = pkgs.writeText "mdev.conf" config.services.mdev.coldplugRules;
-      }
-      {
-        source = devDiskScript;
-        target = "/etc/mdev-disk.sh";
-      }
-    ];
-  } // mkIf cfg.useDaemon {
-    finit.services.mdev = {
-      description = "device event daemon (mdev)";
-      command = "${cfg.package}/bin/busybox mdev -df -S"
-        + lib.optionalString cfg.debug " -v";
-      runlevels = "S12345789";
-      conditions = "run/modalias-load/success";
-      cgroup.name = "init";
-      notify = "pid";
-      log = true;
-
-      # TODO: now we're hijacking `env` and no one else can use it...
-      path = [
-        config.programs.coreutils.package
-        pkgs.util-linux
-      ];
-    };
-
-    boot.initrd.finit.services.mdevd = {
-      description = "device event daemon (mdevd)";
-      command = "mdev -df";
-      notify = "pid";
-    };
-  } // mkIf (!cfg.useDaemon) {
-    finit.tasks.register-hotplug = {
-      description = "Registering kernel hotplug";
-      command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
-      runlevels = "S";
-      cgroup.name = "init";
-      log = true;
-    };
-
-    finit.tasks.coldplug = {
-      description = "Cold plugging system";
-      command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
-      runlevels = "S";
-      conditions = "run/modalias-load/success";
-      cgroup.name = "init";
-      log = true;
-    };
-
-    boot.initrd.finit.run.register-hotplug = {
-      command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
-      priority = 200;
-    };
-
-    boot.initrd.finit.run.coldplug = {
-      command = "mdev -s";
-      priority = 220;
-    };
-
-    boot.kernelPatches = [
-      {
-        name = "uevent-helper";
-        patch = null;
-        structuredExtraConfig = {
-          UEVENT_HELPER = lib.mkForce lib.kernel.yes;
-        };
-      }
-    ];
-  };
+    })
+  ]);
 }

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -349,7 +349,7 @@ in
       boot.initrd.finit.services.mdev = {
         description = "device event daemon (mdev)";
         command = "mdev -df";
-        priority = 230;
+        conditions = "run/coldplug/success";
       };
     })
 

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -48,7 +48,7 @@ let
       mouse[0-9]+  0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
       js[0-9]+     0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
       mice         0:${input}         660 =input/ @${libudev-zero-helper}/bin/helper
-   '';
+    '';
 
   # Insert modules for devices with a modalias.
   modaliasRule = ''-$MODALIAS=.* 0:0 660 @${pkgs.kmod}/bin/modprobe --quiet "$MODALIAS"'';
@@ -286,9 +286,7 @@ in
 
     finit.tasks.coldplug = {
       description = "Cold plugging system";
-      command =
-        "${cfg.package}/bin/busybox mdev -s"
-        + lib.optionalString cfg.debug " -v";
+      command = "${cfg.package}/bin/busybox mdev -s" + lib.optionalString cfg.debug " -v";
       runlevels = "S";
       conditions = "run/modalias-load/success";
       cgroup.name = "init";

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -242,16 +242,16 @@ in
       type = types.bool;
       default = true;
       description = ''
-        `mdev` can be invoked in 2 ways. The first is to not 
+        `mdev` can be invoked in 2 ways. The first (`false`) is to not 
         daemonise, and instead use the legacy /proc/sys/kernel/hotplug
         file to handle hotplugging by the mechanism of the kernel
         forking `mdev` every time a uevent comes thorugh. This will 
         likely require recompiling the kernel.
 
-        The second way is to use the `mdev -d` command, introduced
-        in busybox 1.31.0, allows the `mdev` process to run as a
-        system service. This does not require recompiling the kernel
-        and is recommended for most users.
+        The second way (`true`) is to use the `mdev -d` command, 
+        introduced in busybox 1.31.0, allows the `mdev` process to run 
+        as a system service. This does not require recompiling the
+        kernel and is recommended for most users.
       '';
     };
   };
@@ -293,7 +293,6 @@ in
         log = true;
       };
 
-
       system.activation.scripts.mdev = lib.mkIf config.boot.kernel.enable {
         text = ''
           # Allow the kernel to find our firmware.
@@ -305,7 +304,6 @@ in
 
       system.switch.inhibitors.device-manager = "mdev";
 
-      # build out the default initramfs image
       # TODO: always reports as fail, maybe wrap it as seen in the comment?
       boot.initrd.finit.run.modalias-load = {
         # command = "/bin/sh -c 'find /sys/devices -name modalias -type f | xargs -r cat | sort -u | xargs -r -n1 modprobe -q'";
@@ -342,11 +340,16 @@ in
           pkgs.util-linux
         ];
       };
+      
+      boot.initrd.finit.run.coldplug = {
+        command = "mdev -s";
+        priority = 220;
+      };
 
-      boot.initrd.finit.services.mdevd = {
-        description = "device event daemon (mdevd)";
+      boot.initrd.finit.services.mdev = {
+        description = "device event daemon (mdev)";
         command = "mdev -df";
-        notify = "pid";
+        priority = 230;
       };
     })
 

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -344,12 +344,10 @@ in
       ];
     };
 
-    boot.initrd = {
-      finit.services.mdevd = {
-        description = "device event daemon (mdevd)";
-        command = "mdev -df";
-        notify = "pid";
-      };
+    boot.initrd.finit.services.mdevd = {
+      description = "device event daemon (mdevd)";
+      command = "mdev -df";
+      notify = "pid";
     };
   } // mkIf (!cfg.useDaemon) {
     finit.tasks.register-hotplug = {
@@ -369,16 +367,14 @@ in
       log = true;
     };
 
-    boot.initrd = {
-      finit.run.register-hotplug = {
-        command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
-        priority = 200;
-      };
+    boot.initrd.finit.run.register-hotplug = {
+      command = "echo ${cfg.package}/bin/mdev > /proc/sys/kernel/hotplug";
+      priority = 200;
+    };
 
-      finit.run.coldplug = {
-        command = "mdev -s";
-        priority = 220;
-      };
+    boot.initrd.finit.run.coldplug = {
+      command = "mdev -s";
+      priority = 220;
     };
 
     boot.kernelPatches = [

--- a/modules/services/mdev/default.nix
+++ b/modules/services/mdev/default.nix
@@ -335,10 +335,12 @@ in
         log = true;
 
         # TODO: now we're hijacking `env` and no one else can use it...
+        /*
         path = [
           config.programs.coreutils.package
           pkgs.util-linux
         ];
+        */
       };
       
       boot.initrd.finit.run.coldplug = {


### PR DESCRIPTION
Initialises mdev support! Notable thing that's untested is the kernel thing, no idea if it works I'm just running my own lol :P

Tested with hyprland and xorg. hyprland won't work right now thought as I'm lazy and haven't updated the modules

TODO
- [ ] Abstract the udevApi thing properly into a providers interface. Not *necessary* but it's getting crowded :smile:
- [ ] Add mdev -d support