### PR TITLE
finit: make coldplug non-blocking and fix resulting boot races

### DIFF
--- a/modules/finit/mount.nix
+++ b/modules/finit/mount.nix
@@ -61,10 +61,19 @@ let
     else
       [ ];
 
+  # Full settle: every device triggered and processed. For consumers that can't tolerate a device being absent *yet*.
   deviceConditions =
     lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ]
     ++ lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
     ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
+    ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ];
+
+  # Daemon up only: device manager running, but coldplug may still be in flight for other devices.
+  # Fine for tasks that poll for their own device under a timeout; a full settle adds latency, not correctness.
+  deviceReadyConditions =
+    lib.optionals config.services.mdevd.enable [ "service/mdevd/ready" ]
+    ++ lib.optionals config.services.gardendevd.enable [ "service/gardendevd/ready" ]
+    ++ lib.optionals config.services.udev.enable [ "service/udevd/ready" ]
     ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ];
 
   names = map (fs: utils.escapePath fs.mountPoint) mountable;
@@ -80,7 +89,7 @@ in
       (lib.genAttrs' waitDevs (
         fs:
         lib.nameValuePair "wait-dev-${waitDevName fs}" {
-          conditions = deviceConditions;
+          conditions = deviceReadyConditions;
           script = ''
             # 90s total timeout, polled every 0.1s (busybox sleep supports fractional)
             tries=900

--- a/modules/finit/stage1.nix
+++ b/modules/finit/stage1.nix
@@ -177,6 +177,22 @@ let
     };
   };
 
+  # oneshotOpts: options for oneshot stanzas (task, run) only
+  oneshotOpts = {
+    options.required = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether `finit` must wait for this `run`/`task` before leaving runlevel `S` bootstrap), e.g. towards `switch_root`.
+
+        Set to `false` for jobs nothing else needs to finish before boot proceeds (e.g. a full coldplug).
+        Dependents should wait on {option}`conditions` (e.g. `run/NAME/success`) explicitly.
+
+        Maps to upstream `<!...>` / `required = false`; see [upstream docs](https://finit-project.github.io/conditions/).
+      '';
+    };
+  };
+
   # runOpts: options specific to run stanzas
   runOpts = {
     options.priority = lib.mkOption {
@@ -286,7 +302,13 @@ let
       ++ lib.optional (svc.respawn or false) "respawn"
       ++ lib.optional (svc.restart or null != null) "restart:${toString svc.restart}"
       ++ lib.optional (svc.notify or null != null) "notify:${svc.notify}"
-      ++ lib.optional (svc.conditions or [ ] != [ ]) "<${lib.concatStringsSep "," svc.conditions}>"
+      ++ (
+        let
+          noBlock = (svc.required or true) == false;
+        in
+        lib.optional (svc.conditions or [ ] != [ ] || noBlock)
+          "<${lib.optionalString noBlock "!"}${lib.concatStringsSep "," svc.conditions}>"
+      )
       ++ lib.optional (svc.tty or null != null) "tty:${svc.tty}"
       ++ lib.optional (svc.extraConfig or "" != "") svc.extraConfig
       ++ lib.optional (svc.command or null != null) svc.command
@@ -330,6 +352,7 @@ in
         attrsOf (submodule [
           baseOpts
           execOpts
+          oneshotOpts
           scriptOpts
         ]);
       default = { };
@@ -346,6 +369,7 @@ in
         attrsOf (submodule [
           baseOpts
           execOpts
+          oneshotOpts
           runOpts
           scriptOpts
         ]);

--- a/modules/finit/stage1.nix
+++ b/modules/finit/stage1.nix
@@ -306,8 +306,9 @@ let
         let
           noBlock = (svc.required or true) == false;
         in
-        lib.optional (svc.conditions or [ ] != [ ] || noBlock)
-          "<${lib.optionalString noBlock "!"}${lib.concatStringsSep "," svc.conditions}>"
+        lib.optional (
+          svc.conditions or [ ] != [ ] || noBlock
+        ) "<${lib.optionalString noBlock "!"}${lib.concatStringsSep "," svc.conditions}>"
       )
       ++ lib.optional (svc.tty or null != null) "tty:${svc.tty}"
       ++ lib.optional (svc.extraConfig or "" != "") svc.extraConfig

--- a/modules/finit/stage2.nix
+++ b/modules/finit/stage2.nix
@@ -115,6 +115,19 @@ let
         leaves its valid runlevels.
       '';
     };
+
+    options.required = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether `finit` must wait for this `run`/`task` before switching out of runlevel `S` (bootstrap).
+
+        Set to `false` for jobs nothing needs before boot proceeds (e.g. a full coldplug).
+        Dependents should wait via {option}`conditions` (e.g. `run/NAME/success`).
+
+        Maps to upstream `<!...>` / `required = false`; see [upstream docs](https://finit-project.github.io/conditions/).
+      '';
+    };
   };
 
   # baseOpts: options shared by ALL stanza types (service, task, run, tty, sysv)
@@ -690,8 +703,13 @@ let
           svc.supplementary_groups or [ ] != [ ]
         ) ",${lib.concatStringsSep "," svc.supplementary_groups}"
       ))
-      ++ (lib.optional (svc.conditions or [ ] != [ ] || svc.nohup or false == true)
-        "<${lib.optionalString (svc.nohup or false) "!"}${lib.concatStringsSep "," svc.conditions}>"
+      ++ (
+        let
+          # `!` means: nohup for services (no SIGHUP), or a run/task that must not block the runlevel-S switch (required:false).
+          noBlock = (svc.nohup or false) || (svc.required or true) == false;
+        in
+        lib.optional (svc.conditions or [ ] != [ ] || noBlock)
+          "<${lib.optionalString noBlock "!"}${lib.concatStringsSep "," svc.conditions}>"
       )
       ++ (lib.optional (svc.manual or false) "manual:yes")
       ++ (lib.optional (svc.remain or false) "remain:yes")

--- a/modules/finit/stage2.nix
+++ b/modules/finit/stage2.nix
@@ -708,8 +708,9 @@ let
           # `!` means: nohup for services (no SIGHUP), or a run/task that must not block the runlevel-S switch (required:false).
           noBlock = (svc.nohup or false) || (svc.required or true) == false;
         in
-        lib.optional (svc.conditions or [ ] != [ ] || noBlock)
-          "<${lib.optionalString noBlock "!"}${lib.concatStringsSep "," svc.conditions}>"
+        lib.optional (
+          svc.conditions or [ ] != [ ] || noBlock
+        ) "<${lib.optionalString noBlock "!"}${lib.concatStringsSep "," svc.conditions}>"
       )
       ++ (lib.optional (svc.manual or false) "manual:yes")
       ++ (lib.optional (svc.remain or false) "remain:yes")

--- a/modules/services/gardendevd/default.nix
+++ b/modules/services/gardendevd/default.nix
@@ -168,6 +168,10 @@ in
           cgroup.name = "init";
 
           priority = 1;
+
+          # Trigger+settle takes a while; switching out of runlevel S doesn't need all of /dev.
+          # Dependents (syslog, mounts) wait on `run/gardendevctl:2/success` via their own `conditions`.
+          required = false;
         };
       in
       {
@@ -208,11 +212,15 @@ in
           command = "gardendevctl trigger -c add -t all";
           conditions = "service/gardendevd/ready";
           priority = 250;
+
+          # Don't block switch_root on trigger+settle; wait-dev-* tasks poll for their own device.
+          required = false;
         };
         "gardendevctl@2" = {
           command = "gardendevctl settle -t 30";
           conditions = "service/gardendevd/ready";
           priority = 260;
+          required = false;
         };
       };
 

--- a/modules/services/gardendevd/default.nix
+++ b/modules/services/gardendevd/default.nix
@@ -168,10 +168,6 @@ in
           cgroup.name = "init";
 
           priority = 1;
-
-          # Trigger+settle takes a while; switching out of runlevel S doesn't need all of /dev.
-          # Dependents (syslog, mounts) wait on `run/gardendevctl:2/success` via their own `conditions`.
-          required = false;
         };
       in
       {

--- a/modules/services/mdevd/default.nix
+++ b/modules/services/mdevd/default.nix
@@ -207,6 +207,10 @@ in
       conditions = "service/mdevd/ready";
       cgroup.name = "init";
       log = true;
+
+      # Coldplug takes seconds; switching out of runlevel S doesn't need all of /dev.
+      # Dependents (syslog, mounts) wait on `run/coldplug/success` via their own `conditions`.
+      required = false;
     };
 
     # TODO: share between udev and mdevd
@@ -237,6 +241,10 @@ in
         command = "mdevd-coldplug -O 2";
         conditions = "service/mdevd/ready";
         priority = 300;
+
+        # Don't block switch_root on coldplug; wait-dev-* tasks poll for their
+        # own device.
+        required = false;
       };
 
       contents = [

--- a/modules/services/mdevd/default.nix
+++ b/modules/services/mdevd/default.nix
@@ -207,10 +207,6 @@ in
       conditions = "service/mdevd/ready";
       cgroup.name = "init";
       log = true;
-
-      # Coldplug takes seconds; switching out of runlevel S doesn't need all of /dev.
-      # Dependents (syslog, mounts) wait on `run/coldplug/success` via their own `conditions`.
-      required = false;
     };
 
     # TODO: share between udev and mdevd

--- a/modules/services/rsyslog/default.nix
+++ b/modules/services/rsyslog/default.nix
@@ -51,11 +51,13 @@ in
     finit.services.syslogd = {
       description = "system logging daemon";
       runlevels = "S0123456789";
+      # Daemon up, not full settle: coldplug/settle may be non-blocking or killed at the runlevel change
+      # syslogd must not wait on their success
       conditions =
-        lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
-        ++ lib.optionals config.services.keventd.enable [ "pid/keventd" ]
-        ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
-        ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
+        lib.optionals config.services.gardendevd.enable [ "service/gardendevd/ready" ]
+        ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ]
+        ++ lib.optionals config.services.udev.enable [ "service/udevd/ready" ]
+        ++ lib.optionals config.services.mdevd.enable [ "service/mdevd/ready" ];
       command = "${pkgs.rsyslog-light}/bin/rsyslogd -n -d -f ${configFile}";
     };
 

--- a/modules/services/sysklogd/default.nix
+++ b/modules/services/sysklogd/default.nix
@@ -70,11 +70,13 @@ in
     finit.services.syslogd = {
       description = "system logging daemon";
       runlevels = "S0123456789";
+      # Daemon up, not full settle: coldplug/settle may be non-blocking or killed at the runlevel change
+      # syslogd must not wait on their success
       conditions =
-        lib.optionals config.services.gardendevd.enable [ "run/gardendevctl:2/success" ]
-        ++ lib.optionals config.services.keventd.enable [ "pid/keventd" ]
-        ++ lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
-        ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
+        lib.optionals config.services.gardendevd.enable [ "service/gardendevd/ready" ]
+        ++ lib.optionals config.services.keventd.enable [ "service/keventd/ready" ]
+        ++ lib.optionals config.services.udev.enable [ "service/udevd/ready" ]
+        ++ lib.optionals config.services.mdevd.enable [ "service/mdevd/ready" ];
       command = "${cfg.package}/bin/syslogd -F";
       notify = "pid";
     };


### PR DESCRIPTION
Speeds up boot within runlevel S by adding a `required` option for finit `run`/`task` services and making coldplug/settle non-blocking in the initrd where `wait-dev-*` tasks already poll independently