### PR TITLE
feat: support resume hibernation from swapfile

### DIFF
--- a/modules/boot/kernel.nix
+++ b/modules/boot/kernel.nix
@@ -131,7 +131,13 @@
     boot.resumeDevice = lib.mkOption {
       type = lib.types.str;
       default = "";
-      description = "Device from which to resume after hibernation. Empty = disabled. When set, adds resume=<device> to boot.kernelParams.";
+      example = "/dev/sda3";
+      description = ''
+        Device from which to resume after hibernation. Empty = disabled.
+        Specify here the device where the swap file resides.
+        You should also use boot.kernelParams to specify `resume_offset=`,
+        see more details [here](https://wiki.archlinux.org/title/Power_management/Suspend_and_hibernate#Acquire_swap_file_offset).
+      '';
     };
 
     boot.kernelParams = lib.mkOption {

--- a/modules/filesystems/default.nix
+++ b/modules/filesystems/default.nix
@@ -22,18 +22,21 @@ let
       # their assertions too
       (lib.attrValues config.fileSystems);
 
+  makeSwapOption =
+    sw:
+    lib.concatStringsSep "," (
+      sw.options
+      ++ lib.optional (sw.priority != null) "pri=${toString sw.priority}"
+      ++ lib.optional (sw.discardPolicy != null) (
+        if sw.discardPolicy == "both" then "discard" else "discard=${sw.discardPolicy}"
+      )
+    );
   makeSwapEntry =
     sw:
     let
       device = if sw.label != null then "/dev/disk/by-label/${sw.label}" else sw.device;
-      options =
-        sw.options
-        ++ lib.optional (sw.priority != null) "pri=${toString sw.priority}"
-        ++ lib.optional (sw.discardPolicy != null) (
-          if sw.discardPolicy == "both" then "discard" else "discard=${sw.discardPolicy}"
-        );
     in
-    "${escape device} none swap ${escape (lib.concatStringsSep "," options)} 0 0\n";
+    "${escape device} none swap ${escape (makeSwapOption sw)} 0 0\n";
 
   makeFstabEntries =
     let
@@ -105,10 +108,54 @@ let
 
   # Swap entries with randomEncryption.enable can't be stable fstab lines: the backing device is a fresh /dev/mapper/<name> created with a brand new random key on every boot, so they're set up imperatively instead
   isEncryptedSwap = sw: sw.randomEncryption.enable;
-  plainSwapDevices = lib.filter (sw: !isEncryptedSwap sw) config.swapDevices;
+  isSwapFile = sw: sw.size != null;
+  plainSwapDevices = lib.filter (sw: (!isEncryptedSwap sw) && (!isSwapFile sw)) config.swapDevices;
+  swapFileDevices = lib.filter isSwapFile config.swapDevices;
   encryptedSwapDevices = lib.filter isEncryptedSwap config.swapDevices;
 
   sanitizeName = s: lib.replaceStrings [ "/" " " ] [ "-" "-" ] (lib.removePrefix "/" s);
+
+  makeSwapFileTask =
+    sw:
+    let
+      name = "makeswapfile-${sanitizeName sw.device}";
+      btrfsInSystem = config.boot.supportedFilesystems.btrfs.enable or false;
+      device = sw.device;
+    in
+    {
+      inherit name;
+      value = {
+        description = "Create and enable swap file on ${device}";
+        runlevels = "S";
+        path = [
+          pkgs.e2fsprogs
+          pkgs.btrfs-progs
+          pkgs.util-linux
+          config.programs.coreutils.package
+        ];
+        command = toString (
+          pkgs.writeShellScript name ''
+            currentSize=$(( $(stat -c "%s" "${device}" 2>/dev/null || echo 0) / 1024 / 1024 ))
+            if [[ ! -b "${device}" && "${toString sw.size}" != "$currentSize" ]]; then
+              mkdir -p "$(dirname "${device}")"
+              if [[ "$(stat -f -c %T "$(dirname "${device}")")" == "btrfs" ]]; then
+                # Use btrfs mkswapfile to speed up the creation of swapfile.
+                rm -f "${device}"
+                btrfs filesystem mkswapfile --size "${toString sw.size}M" --uuid clear "${device}"
+              else
+                # Disable CoW for CoW based filesystems.
+                truncate --size 0 "${device}"
+                chattr +C "${device}" 2>/dev/null || true
+
+                dd if=/dev/zero of="${device}" bs=1M count=${toString sw.size} status=progress
+                mkswap "${device}"
+              fi
+            fi
+            swapon -o ${lib.escapeShellArg (makeSwapOption sw)} "${device}"
+          ''
+        );
+      };
+    };
 
   makeEncryptedSwapTask =
     sw:
@@ -120,12 +167,6 @@ let
       value =
         let
           re = sw.randomEncryption;
-          options =
-            sw.options
-            ++ lib.optional (sw.priority != null) "pri=${toString sw.priority}"
-            ++ lib.optional (sw.discardPolicy != null) (
-              if sw.discardPolicy == "both" then "discard" else "discard=${sw.discardPolicy}"
-            );
         in
         {
           description = "Encrypted swap device on ${sw.device}";
@@ -141,7 +182,7 @@ let
                 -d ${lib.escapeShellArg re.source} \
                 ${lib.escapeShellArg sw.device} ${lib.escapeShellArg name}
               ${pkgs.util-linuxMinimal}/bin/mkswap /dev/mapper/${name}
-              ${pkgs.util-linuxMinimal}/bin/swapon -o ${lib.escapeShellArg (lib.concatStringsSep "," options)} /dev/mapper/${name}
+              ${pkgs.util-linuxMinimal}/bin/swapon -o ${lib.escapeShellArg (makeSwapOption sw)} /dev/mapper/${name}
             ''
           );
         };
@@ -176,15 +217,29 @@ in
     # system.fsPackages = [ pkgs.dosfstools ];
     # environment.systemPackages = with pkgs; [ fuse3 fuse ] ++ config.system.fsPackages;
 
-    assertions = lib.map (sw: {
-      assertion = sw.label == null && (builtins.match "/dev/disk/by-(uuid|label)/.*" sw.device == null);
-      message = ''
-        Random-encrypted swap device ${sw.device} must not use swapDevices.*.label,
-        and should not be referenced by UUID or label, since those are erased and regenerated on every
-        boot once the partition is encrypted. Use a stable path such as
-        /dev/disk/by-partuuid/... instead.
-      '';
-    }) encryptedSwapDevices;
+    assertions =
+      (lib.map (sw: {
+        assertion = sw.label == null && (builtins.match "/dev/disk/by-(uuid|label)/.*" sw.device == null);
+        message = ''
+          Random-encrypted swap device ${sw.device} must not use swapDevices.*.label,
+          and should not be referenced by UUID or label, since those are erased and regenerated on every
+          boot once the partition is encrypted. Use a stable path such as
+          /dev/disk/by-partuuid/... instead.
+        '';
+      }) encryptedSwapDevices)
+      ++ (lib.concatMap (sw: [
+        {
+          assertion = sw.randomEncryption.enable == false;
+          message = ''
+            Random encryption on swap file ${sw.device} is not supported.
+            Use encrypted root filesystem instead.
+          '';
+        }
+        {
+          assertion = !(lib.hasPrefix "/dev/" sw.device);
+          message = "Setting the swap size of block device ${sw.device} has no effect";
+        }
+      ]) swapFileDevices);
 
     environment.systemPackages =
       lib.unique (
@@ -196,7 +251,9 @@ in
       )
       ++ lib.optional (encryptedSwapDevices != [ ]) pkgs.cryptsetup;
 
-    finit.tasks = lib.listToAttrs (lib.map makeEncryptedSwapTask encryptedSwapDevices);
+    finit.tasks = lib.listToAttrs (
+      (lib.map makeEncryptedSwapTask encryptedSwapDevices) ++ (lib.map makeSwapFileTask swapFileDevices)
+    );
 
     environment.etc.fstab.text = ''
       # This is a generated file.  Do not edit!

--- a/modules/filesystems/options.nix
+++ b/modules/filesystems/options.nix
@@ -119,6 +119,17 @@ let
           description = "Path of the swap device or file.";
         };
 
+        size = lib.mkOption {
+          default = null;
+          example = 2048;
+          type = lib.types.nullOr lib.types.int;
+          description = ''
+            If this option is set, ‘device’ is interpreted as the
+            path of a swapfile that will be created automatically
+            with the indicated size in MiB (1024×1024 bytes).
+          '';
+        };
+
         label = lib.mkOption {
           default = null;
           example = "swap";

--- a/modules/finit/initrd.nix
+++ b/modules/finit/initrd.nix
@@ -68,69 +68,95 @@ in
   };
 
   config.boot.initrd = {
-    finit.run.setup-stdio = {
-      priority = 100;
-      script = ''
-        ln -sfn /proc/self/fd    /dev/fd
-        ln -sfn /proc/self/fd/0  /dev/stdin
-        ln -sfn /proc/self/fd/1  /dev/stdout
-        ln -sfn /proc/self/fd/2  /dev/stderr
-      '';
-    };
+    finit.run = lib.mkMerge [
+      {
+        setup-stdio = {
+          priority = 100;
+          script = ''
+            ln -sfn /proc/self/fd    /dev/fd
+            ln -sfn /proc/self/fd/0  /dev/stdin
+            ln -sfn /proc/self/fd/1  /dev/stdout
+            ln -sfn /proc/self/fd/2  /dev/stderr
+          '';
+        };
+      }
 
-    finit.run.switch-root = {
-      runlevels = "1";
-      script = ''
-        # process the kernel command line to find init=
-        stage2Init=/init
-        for o in $(cat /proc/cmdline); do
-          case $o in
-            init=*)
-              set -- $(IFS==; echo $o)
-              stage2Init=$2
-              ;;
-          esac
-        done
+      (lib.optionalAttrs (config.boot.resumeDevice != "") {
+        resume-hibernation = {
+          priority = 400;
+          conditions = [ "task/wait-dev-resume/success" ];
+          script = ''
+            if [ ! -e /sys/power/resume ]; then
+              printf 'resume-hibernation: no hibernation support found' >&2
+              exit 1
+            fi
 
-        # TODO: modify `initctl switch-root` call in finit to have a proper return code
-        if [ ! -d /sysroot ] || ! mountpoint -q /sysroot || [ ! -x "/sysroot$stage2Init" ]; then
-          cat > /dev/console <<EOF
+            set -- $(stat -L -c '%t %T' "${config.boot.resumeDevice}")
+            if [ -z "''${1:-}" ] || [ -z "''${2:-}" ]; then
+              echo "resume-hibernation: cannot determine device numbers of ${config.boot.resumeDevice}" >&2
+              exit 1
+            fi
+            printf '%d:%d' "$((0x$1))" "$((0x$2))" >/sys/power/resume
+          '';
+        };
+      })
 
-        ==========================================
-        ${
-          if !grantAccess then
-            ''
-              rescue shell is disabled
+      {
+        switch-root = {
+          runlevels = "1";
+          script = ''
+            # process the kernel command line to find init=
+            stage2Init=/init
+            for o in $(cat /proc/cmdline); do
+              case $o in
+                init=*)
+                  set -- $(IFS==; echo $o)
+                  stage2Init=$2
+                  ;;
+              esac
+            done
 
-              rebooting in 10s
-            ''
-          else
-            ''
-              to diagnose:   initctl status; initctl cond dump
-              to continue:   initctl switch-root /sysroot $stage2Init
-              to reboot:     reboot -f
-            ''
-        }
+            # TODO: modify `initctl switch-root` call in finit to have a proper return code
+            if [ ! -d /sysroot ] || ! mountpoint -q /sysroot || [ ! -x "/sysroot$stage2Init" ]; then
+              cat > /dev/console <<EOF
 
-        EOF
-          ${
-            if !grantAccess then
-              ''
-                sleep 10
-                exec reboot -f
-              ''
-            else
-              # exit non-zero so finit emits <run/switch-root/failure>,
-              # which triggers the rescue tty in finit.conf
-              ''
-                exit 1
-              ''
-          }
-        fi
+            ==========================================
+            ${
+              if !grantAccess then
+                ''
+                  rescue shell is disabled
 
-        exec initctl switch-root /sysroot "$stage2Init"
-      '';
-    };
+                  rebooting in 10s
+                ''
+              else
+                ''
+                  to diagnose:   initctl status; initctl cond dump
+                  to continue:   initctl switch-root /sysroot $stage2Init
+                  to reboot:     reboot -f
+                ''
+            }
+
+            EOF
+              ${
+                if !grantAccess then
+                  ''
+                    sleep 10
+                    exec reboot -f
+                  ''
+                else
+                  # exit non-zero so finit emits <run/switch-root/failure>,
+                  # which triggers the rescue tty in finit.conf
+                  ''
+                    exit 1
+                  ''
+              }
+            fi
+
+            exec initctl switch-root /sysroot "$stage2Init"
+          '';
+        };
+      }
+    ];
 
     finit.ttys.rescue = {
       runlevels = "1";

--- a/modules/finit/mount.nix
+++ b/modules/finit/mount.nix
@@ -73,13 +73,22 @@ let
     lib.attrValues config.fileSystems
   );
   waitDevName = fs: utils.escapePath (if isPseudo fs then fs.device else fs.mountPoint);
+  waitDevPairs =
+    (map (fs: {
+      name = waitDevName fs;
+      device = fs.device;
+    }) waitDevs)
+    ++ (lib.optional (config.boot.resumeDevice != "") {
+      name = "resume";
+      device = config.boot.resumeDevice;
+    });
 in
 {
   config = {
     boot.initrd.finit.tasks = lib.mkMerge [
-      (lib.genAttrs' waitDevs (
+      (lib.genAttrs' waitDevPairs (
         fs:
-        lib.nameValuePair "wait-dev-${waitDevName fs}" {
+        lib.nameValuePair "wait-dev-${fs.name}" {
           conditions = deviceConditions;
           script = ''
             # 90s total timeout, polled every 0.1s (busybox sleep supports fractional)


### PR DESCRIPTION
Previously `resumeDevice` only added `resume=` to `kernelParams` to lead kernel resume from hibernation. But the early kernel may not be able to access that device properly before device manager is initialized, and cause regular booting with `Image not found` instead of resuming.

This implementation refers to the resume hook of `mkinitcpio` and  `nixos`. With a `wait-dev-resume` finit task condition, we can ensure the resume device is usable before we run the resume script in early stage1.
I also added support for creating swap file automatically with specific size, by using a finit task in stage2.

The relations among swap file, encryption and hibernation are really complex, so some of the edge cases may not be well covered.
But for now, I tested hibernation resuming from swap partition and swap file with `ZZZ` and `btrfs`. It slept peacefully💤.