### PR TITLE
modules/services/gvfs: enable udev support for udev compatibile device managers

### DIFF
--- a/modules/services/gvfs/default.nix
+++ b/modules/services/gvfs/default.nix
@@ -23,7 +23,9 @@ in
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.gvfs.override {
-        udevSupport = config.services.udev.enable;
+        # requires a device manager that can read udev rules
+        udevSupport =
+          config.services.udev.enable || config.services.gardendevd.enable || config.services.keventd.enable;
       };
       defaultText = lib.literalExpression "pkgs.gvfs";
       description = ''


### PR DESCRIPTION
turns out gvfs did not need to run as a finit service for this to work! 