### PR TITLE
virtualisation: add android module (binder/ashmem + waydroid)

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -73,3 +73,8 @@ in
 }
 // programModules
 // serviceModules
+// {
+  # virtualisation
+
+  android = ./virtualisation/android.nix;
+}

--- a/modules/virtualisation/android.nix
+++ b/modules/virtualisation/android.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.virtualisation.android;
+in
+{
+  options.virtualisation.android.enable = lib.mkEnableOption "Android container support (Waydroid)";
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [
+      "binder_linux"
+      "ashmem_linux"
+    ];
+
+    services.dbus.packages = [ pkgs.waydroid-nftables ];
+  };
+}


### PR DESCRIPTION
Loads `binder_linux` and `ashmem_linux` kernel modules and ships the Waydroid dbus policy (`id.waydro.Container`) so Waydroid can boot an Android container.

Usage:
```nix
virtualisation.android.enable = true;
```