### PR TITLE
sddm: options to change package and add extraPackages

### DIFF
--- a/modules/services/sddm/default.nix
+++ b/modules/services/sddm/default.nix
@@ -10,6 +10,10 @@ let
 
   format = pkgs.formats.ini { };
   configFile = format.generate "sddm.conf" cfg.settings;
+
+  package' = cfg.package.override (prev: {
+    extraPackages = prev.extraPackages or [ ] ++ cfg.extraPackages;
+  });
 in
 {
   imports = [ modules.xorg ];
@@ -20,6 +24,34 @@ in
       default = false;
       description = ''
         Whether to enable [sddm](${pkgs.kdePackages.sddm.meta.homepage}) as a system service.
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.kdePackages.sddm;
+      defaultText = lib.literalExpression "pkgs.kdePackages.sddm";
+      description = ''
+        The package to use for `sddm`.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      example = ''
+        with pkgs.kdePackages; [
+          breeze-icons
+          kirigami
+          libplasma
+          plasma5support
+          qtmultimedia
+          qtsvg
+          qtvirtualkeyboard
+        ]
+      '';
+      description = ''
+        Extra Qt plugins / QML libraries to add to the environment.
       '';
     };
 
@@ -64,7 +96,7 @@ in
         # MinimumVT = 7;
         ServerPath = "${config.programs.xorg.package.out}/bin/X";
         XephyrPath = "${config.programs.xorg.package.out}/bin/Xephyr";
-        SessionCommand = "${pkgs.kdePackages.sddm}/share/sddm/scripts/Xsession";
+        SessionCommand = "${package'}/share/sddm/scripts/Xsession";
         SessionDir = "/run/current-system/sw/share/xsessions";
         XauthPath = "${pkgs.xauth}/bin/xauth";
         # DisplayCommand = toString Xsetup;
@@ -77,7 +109,7 @@ in
         ServerArguments = "-logverbose 6 -xkbdir ${config.programs.xorg.xkb.dir} -terminate -verbose 7";
       };
       Wayland = {
-        SessionCommand = "${pkgs.kdePackages.sddm}/share/sddm/scripts/wayland-session";
+        SessionCommand = "${package'}/share/sddm/scripts/wayland-session";
         SessionDir = "/run/current-system/sw/share/wayland-sessions";
 
         # Path to the user session log file
@@ -104,10 +136,10 @@ in
       "X       /tmp/xauth_*"
     ];
 
-    services.dbus.packages = [ pkgs.kdePackages.sddm ];
+    services.dbus.packages = [ package' ];
 
     environment.systemPackages = [
-      pkgs.kdePackages.sddm
+      package'
     ];
 
     environment.etc."sddm.conf".source = configFile;


### PR DESCRIPTION
This PR adds the option for users to pass `extraPackages` into the `sddm` wrapper instead of adding those globally to system packages. As an example, this allows users to pass libraries needed for certain themes, such as `qtmultimedia`.