### PR TITLE
modules/pam: include per-user profile in `XDG_DATA_DIRS`

### DIFF
--- a/modules/security/pam/default.nix
+++ b/modules/security/pam/default.nix
@@ -144,7 +144,10 @@ in
         "/etc/xdg"
         "/run/current-system/sw/etc/xdg"
       ];
-      XDG_DATA_DIRS = [ "/run/current-system/sw/share" ];
+      XDG_DATA_DIRS = [
+        "/run/current-system/sw/share"
+        "/etc/profiles/per-user/@{PAM_USER}/share"
+      ];
     };
 
     security.pam.services.other = {


### PR DESCRIPTION
this change primarily fixes launchers not being able to discover .desktop files installed as user packages by including per-user profile in `XDG_DATA_DIRS`