### PR TITLE
environment: add attrset-based 'packageSet' option

### DIFF
--- a/modules/environment/path/default.nix
+++ b/modules/environment/path/default.nix
@@ -4,11 +4,58 @@
   lib,
   ...
 }:
+let
+  corePackages = lib.mapAttrs (_: lib.mkDefault) (
+    with pkgs;
+    {
+      inherit
+        acl
+        attr
+        cpio
+        curl
+        diffutils
+        findutils
+        getent
+        getconf
+        less
+        libcap
+        ncurses
+        mkpasswd
+        netcat
+        procps
+        su
+        time
+        util-linux
+        which
+        zstd
+        bashInteractive
+        gnugrep
+        gnused
+        gnutar
+        ;
+
+      # If package name won't match key, we can do:
+      # grep = busybox;
+    }
+  );
+in
 {
   options = {
     environment.systemPackages = lib.mkOption {
       type = with lib.types; listOf package;
       default = { };
+    };
+
+    environment.packageSet = lib.mkOption {
+      type = with lib.types; attrsOf (nullOr package);
+      default = { };
+      description = ''
+        Experimental option, where packages are defined as an attribute set.
+        Follows format "environment.packageSet.foo = lib.mkDefault pkgs.foo | null;".
+
+        Expands into "environment.systemPackages", but this
+        format allows to remove packages from system closure in a targeted manner.
+      '';
     };
 
     environment.pathsToLink = lib.mkOption {
@@ -31,36 +78,13 @@
   };
 
   config = {
-    environment.systemPackages = with pkgs; [
-      acl
-      attr
-      bzip2
-      cpio
-      curl
-      diffutils
-      findutils
-      getent
-      getconf
-      gzip
-      xz
-      less
-      libcap
-      ncurses
-      netcat
-      mkpasswd
-      procps
-      su
-      time
-      util-linux
-      which
-      zstd
+    environment.packageSet = corePackages;
+    environment.systemPackages = lib.mkMerge [
+      (with pkgs; [ ])
 
-      bashInteractive
-      gawk
-      gnugrep
-      gnupatch
-      gnused
-      gnutar
+      (lib.mkAfter (
+        lib.unique (lib.filter (pkg: pkg != null) (lib.attrValues config.environment.packageSet))
+      ))
     ];
 
     environment.pathsToLink = [


### PR DESCRIPTION
Introduce the option to write packages as an attribute set. 
Those will format the format `environment.packageSet*.foo = pkgs.foo | null;`, and should be applicable both for individual packages and those added via modules.

Takes the idea from the PR but massively cuts down on its scope given it added changes to libraries as well. Think of it as *something* to start the work with.

<details>
<summary>All options enabled:</summary>

```Nix
nix-repl> options.environment.packageSet.value
{
  acl = «derivation /nix/store/8hrbgd0bk7jkairx6kwwys0s4mb4klii-acl-2.4.0.drv»;
  attr = «derivation /nix/store/g312j0pr0k224mdwrvalqc4ll77j2vv1-attr-2.6.0.drv»;
  bashInteractive = «derivation /nix/store/6m17d0hk048xgklqrblndd6hxbx536x9-bash-interactive-5.3p15.drv»;
  cpio = «derivation /nix/store/32v0mzxq3z946mn7dag4k4a9zgaajib3-cpio-2.15.drv»;
  curl = «derivation /nix/store/n6mbhphh51pv5i3hvzhjmkmmchqg49m8-curl-8.21.0.drv»;
  diffutils = «derivation /nix/store/kzk5ygqbvqxaasq1pnmsb4zg23ajvfd2-diffutils-3.12.drv»;
  findutils = «derivation /nix/store/xpl0w0qihn3hkcp45yp66azpwpv758kc-findutils-4.11.0.drv»;
  getconf = «derivation /nix/store/41x46hq787rrkcqipqz59agnm36kgix2-getconf-glibc-2.42-67.drv»;
  getent = «derivation /nix/store/r55p393q0mdqibnp8kpk28kp25mb8jh8-getent-glibc-2.42-67.drv»;
  gnugrep = «derivation /nix/store/2x5g1wwj14ch6wa7782lxbgzym2pymkd-gnugrep-3.12.drv»;
  gnused = «derivation /nix/store/s4ijilaq90sqdldphllbi1xvc8kima72-gnused-4.10.drv»;
  gnutar = «derivation /nix/store/d4jask0xgd9nn552f9y8pvb86v9507pp-gnutar-1.35.drv»;
  less = «derivation /nix/store/kz6vw9jpyqai3rygvdj5m5760d0sj4l9-less-704.drv»;
  libcap = «derivation /nix/store/95h52lw74mxiaq9mc4m52qzplzvircps-libcap-2.78.drv»;
  mkpasswd = «derivation /nix/store/qgaynm2f64f0g3gc74k157dwbbc0xlyh-mkpasswd-5.6.6.drv»;
  ncurses = «derivation /nix/store/qs2scai2zrmpp93ky2prvm3aq6vvyhpl-ncurses-6.6.drv»;
  netcat = «derivation /nix/store/yhcxfxngr5ih1mgl1vjjqacp0lzjwxc3-libressl-4.3.2.drv»;
  procps = «derivation /nix/store/95r9kk11svcvj28xhn0nyk5z1sbrw36x-procps-4.0.6.drv»;
  su = «derivation /nix/store/7r1n389qzv8bdqvf2jk4zfhpwqgmib7j-shadow-4.20.0.drv»;
  time = «derivation /nix/store/vfc28w92hidpr4mnvvak9hyp6k37ryxp-time-1.10.drv»;
  util-linux = «derivation /nix/store/d3ndg8sj09hmzi4aihfyrlz38ibq1h76-util-linux-2.42.2.drv»;
  which = «derivation /nix/store/g4idsxw9rl07km9lbqdqpx60c6qza21w-which-2.25.drv»;
  zstd = «derivation /nix/store/h8jz38akacp477q2xz0snx63fhcp6inr-zstd-1.5.7.drv»;
}

nix-repl> builtins.elem pkgs.which config.environment.systemPackages
true
```

</details>

<details>
<summary>User sets environment.packageSet.which = null;</summary>

```Nix
{
  acl = «derivation /nix/store/8hrbgd0bk7jkairx6kwwys0s4mb4klii-acl-2.4.0.drv»;
  attr = «derivation /nix/store/g312j0pr0k224mdwrvalqc4ll77j2vv1-attr-2.6.0.drv»;
  bashInteractive = «derivation /nix/store/6m17d0hk048xgklqrblndd6hxbx536x9-bash-interactive-5.3p15.drv»;
  cpio = «derivation /nix/store/32v0mzxq3z946mn7dag4k4a9zgaajib3-cpio-2.15.drv»;
  curl = «derivation /nix/store/n6mbhphh51pv5i3hvzhjmkmmchqg49m8-curl-8.21.0.drv»;
  diffutils = «derivation /nix/store/kzk5ygqbvqxaasq1pnmsb4zg23ajvfd2-diffutils-3.12.drv»;
  findutils = «derivation /nix/store/xpl0w0qihn3hkcp45yp66azpwpv758kc-findutils-4.11.0.drv»;
  getconf = «derivation /nix/store/41x46hq787rrkcqipqz59agnm36kgix2-getconf-glibc-2.42-67.drv»;
  getent = «derivation /nix/store/r55p393q0mdqibnp8kpk28kp25mb8jh8-getent-glibc-2.42-67.drv»;
  gnugrep = «derivation /nix/store/2x5g1wwj14ch6wa7782lxbgzym2pymkd-gnugrep-3.12.drv»;
  gnused = «derivation /nix/store/s4ijilaq90sqdldphllbi1xvc8kima72-gnused-4.10.drv»;
  gnutar = «derivation /nix/store/d4jask0xgd9nn552f9y8pvb86v9507pp-gnutar-1.35.drv»;
  less = «derivation /nix/store/kz6vw9jpyqai3rygvdj5m5760d0sj4l9-less-704.drv»;
  libcap = «derivation /nix/store/95h52lw74mxiaq9mc4m52qzplzvircps-libcap-2.78.drv»;
  mkpasswd = «derivation /nix/store/qgaynm2f64f0g3gc74k157dwbbc0xlyh-mkpasswd-5.6.6.drv»;
  ncurses = «derivation /nix/store/qs2scai2zrmpp93ky2prvm3aq6vvyhpl-ncurses-6.6.drv»;
  netcat = «derivation /nix/store/yhcxfxngr5ih1mgl1vjjqacp0lzjwxc3-libressl-4.3.2.drv»;
  procps = «derivation /nix/store/95r9kk11svcvj28xhn0nyk5z1sbrw36x-procps-4.0.6.drv»;
  su = «derivation /nix/store/7r1n389qzv8bdqvf2jk4zfhpwqgmib7j-shadow-4.20.0.drv»;
  time = «derivation /nix/store/vfc28w92hidpr4mnvvak9hyp6k37ryxp-time-1.10.drv»;
  util-linux = «derivation /nix/store/d3ndg8sj09hmzi4aihfyrlz38ibq1h76-util-linux-2.42.2.drv»;
  which = null;
  zstd = «derivation /nix/store/h8jz38akacp477q2xz0snx63fhcp6inr-zstd-1.5.7.drv»;
}

nix-repl> builtins.elem pkgs.which config.environment.systemPackages
false
```

</details>

<details open>
<summary>User replaces gnused with busybox (environment.packageSet.gnused = pkgs.busybox;)**:</summary>

```Nix
nix-repl> options.environment.packageSet.value                       
{
  acl = «derivation /nix/store/8hrbgd0bk7jkairx6kwwys0s4mb4klii-acl-2.4.0.drv»;
  attr = «derivation /nix/store/g312j0pr0k224mdwrvalqc4ll77j2vv1-attr-2.6.0.drv»;
  bashInteractive = «derivation /nix/store/6m17d0hk048xgklqrblndd6hxbx536x9-bash-interactive-5.3p15.drv»;
  cpio = «derivation /nix/store/32v0mzxq3z946mn7dag4k4a9zgaajib3-cpio-2.15.drv»;
  curl = «derivation /nix/store/n6mbhphh51pv5i3hvzhjmkmmchqg49m8-curl-8.21.0.drv»;
  diffutils = «derivation /nix/store/kzk5ygqbvqxaasq1pnmsb4zg23ajvfd2-diffutils-3.12.drv»;
  findutils = «derivation /nix/store/xpl0w0qihn3hkcp45yp66azpwpv758kc-findutils-4.11.0.drv»;
  getconf = «derivation /nix/store/41x46hq787rrkcqipqz59agnm36kgix2-getconf-glibc-2.42-67.drv»;
  getent = «derivation /nix/store/r55p393q0mdqibnp8kpk28kp25mb8jh8-getent-glibc-2.42-67.drv»;
  gnugrep = «derivation /nix/store/2x5g1wwj14ch6wa7782lxbgzym2pymkd-gnugrep-3.12.drv»;
  gnused = «derivation /nix/store/vzn2khbdbal8cpy4qyxj6dydjccnmwl0-busybox-1.37.0.drv»;
  gnutar = «derivation /nix/store/d4jask0xgd9nn552f9y8pvb86v9507pp-gnutar-1.35.drv»;
  less = «derivation /nix/store/kz6vw9jpyqai3rygvdj5m5760d0sj4l9-less-704.drv»;
  libcap = «derivation /nix/store/95h52lw74mxiaq9mc4m52qzplzvircps-libcap-2.78.drv»;
  mkpasswd = «derivation /nix/store/qgaynm2f64f0g3gc74k157dwbbc0xlyh-mkpasswd-5.6.6.drv»;
  ncurses = «derivation /nix/store/qs2scai2zrmpp93ky2prvm3aq6vvyhpl-ncurses-6.6.drv»;
  netcat = «derivation /nix/store/yhcxfxngr5ih1mgl1vjjqacp0lzjwxc3-libressl-4.3.2.drv»;
  procps = «derivation /nix/store/95r9kk11svcvj28xhn0nyk5z1sbrw36x-procps-4.0.6.drv»;
  su = «derivation /nix/store/7r1n389qzv8bdqvf2jk4zfhpwqgmib7j-shadow-4.20.0.drv»;
  time = «derivation /nix/store/vfc28w92hidpr4mnvvak9hyp6k37ryxp-time-1.10.drv»;
  util-linux = «derivation /nix/store/d3ndg8sj09hmzi4aihfyrlz38ibq1h76-util-linux-2.42.2.drv»;
  which = «derivation /nix/store/g4idsxw9rl07km9lbqdqpx60c6qza21w-which-2.25.drv»;
  zstd = «derivation /nix/store/h8jz38akacp477q2xz0snx63fhcp6inr-zstd-1.5.7.drv»;
}

nix-repl> builtins.elem pkgs.gnused config.environment.systemPackages
false

nix-repl> builtins.elem pkgs.busybox config.environment.systemPackages
true
```

</details>

##### * Option name is subject to change if needed.
##### ** Because of how busybox works, it is necessary to manually disable other packages with provided by it, especially if the goal is to remove those from closure.