### PR TITLE
Add warning when no providers.scheduler.backend backend is selected

### DIFF
--- a/modules/providers/scheduler/default.nix
+++ b/modules/providers/scheduler/default.nix
@@ -1,4 +1,8 @@
-{ lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
   pathOrStr = with lib.types; coercedTo path (x: "${x}") str;
   program =
@@ -78,4 +82,15 @@ in
       '';
     };
   };
+
+  config.warnings =
+    lib.optionals
+      (config.providers.scheduler.tasks != { } && config.providers.scheduler.backend == "none")
+      [
+        ''
+          no scheduler provider backend has been enabled, yet the following scheduled tasks are defined:
+          ${lib.concatStringsSep ", " (lib.attrNames config.providers.scheduler.tasks)}
+          select a backend implementation to use scheduled tasks
+        ''
+      ];
 }

--- a/modules/services/docker/default.nix
+++ b/modules/services/docker/default.nix
@@ -198,13 +198,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = cfg.prune.enable -> config.providers.scheduler.backend != "none";
-        message = "services.docker.prune.enable requires a scheduler backend to be enabled in your system configuration.";
-      }
-    ];
-
     services.docker.settings = {
       inherit (cfg) group;
     };


### PR DESCRIPTION
and remove the assertion in the docker service related to the same issue