### PR TITLE
modules/cosmic-session: init

### DIFF
--- a/modules/programs/cosmic-applets/default.nix
+++ b/modules/programs/cosmic-applets/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  pkgs,
+  config,
+  modules,
+  ...
+}:
+let
+  inherit (lib) types;
+  cfg = config.programs.cosmic-applets;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+in
+{
+  imports = [
+    modules.pipewire
+  ];
+
+  options = {
+    programs.cosmic-applets = {
+      enable = lib.mkEnableOption "COSMIC applets";
+      package = lib.mkOption {
+        type = types.package;
+        default = pkgs.cosmic-applets.override {
+          udev = udevApi;
+          libinput = pkgs.libinput.override (
+            lib.optionalAttrs (udevApi != null) {
+              udev = udevApi;
+              wacomSupport = false;
+            }
+          );
+          pipewire = config.programs.pipewire.package;
+        };
+        defaultText = lib.literalExpression "pkgs.cosmic-applets";
+        description = ''
+          The package to use for `cosmic-applets`.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+  };
+}

--- a/modules/programs/cosmic-comp/default.nix
+++ b/modules/programs/cosmic-comp/default.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+  cfg = config.programs.cosmic-comp;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+  sessionFile = pkgs.writeTextDir "share/wayland-sessions/cosmic.desktop" ''
+    [Desktop Entry]
+    Name=COSMIC
+    Comment=This session logs you into the COSMIC desktop
+    Comment[sv]=Denna session loggar in dig till skrivbordsmiljön COSMIC
+    Exec=${pkgs.dbus}/bin/dbus-run-session -- ${lib.getExe cfg.package}
+    Type=Application
+    DesktopNames=COSMIC
+  '';
+in
+{
+  options = {
+    programs.cosmic-comp = {
+      enable = lib.mkEnableOption "COSMIC compositor";
+      package = lib.mkOption {
+        type = types.package;
+        default = pkgs.cosmic-comp.override {
+          useSystemd = false;
+          udev = udevApi;
+          libinput = pkgs.libinput.override (
+            lib.optionalAttrs (udevApi != null) {
+              udev = udevApi;
+              wacomSupport = false;
+            }
+          );
+        };
+        defaultText = lib.literalExpression "pkgs.cosmic-comp";
+        description = ''
+          The package to use for `cosmic-comp`.
+        '';
+      };
+      xwayland.enable = lib.mkEnableOption "Xwayland support for the COSMIC compositor" // {
+        default = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      # cosmic-comp doesn't install a session file by itself so `lib.hiPrio` is unnecessary
+      # and by setting it to `lib.lowPrio` we let `cosmic-session` install its own session file
+      # which depending on availability of `DBUS_SESSION_BUS_ADDRESS` runs `dbus-run-session`
+      (lib.lowPrio sessionFile)
+    ]
+    ++ lib.optionals cfg.xwayland.enable [ pkgs.xwayland ];
+  };
+}

--- a/modules/programs/cosmic-edit/default.nix
+++ b/modules/programs/cosmic-edit/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.cosmic-edit;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+  libinput = pkgs.libinput.override (
+    lib.optionalAttrs (udevApi != null) {
+      udev = udevApi;
+      wacomSupport = false;
+    }
+  );
+in
+{
+  options.programs.cosmic-edit = {
+    enable = lib.mkEnableOption "COSMIC edit";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.cosmic-edit.override { inherit libinput; };
+      defaultText = lib.literalExpression "pkgs.cosmic-edit";
+      description = ''
+        The package to use for `cosmic-edit`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/modules/programs/cosmic-osd/default.nix
+++ b/modules/programs/cosmic-osd/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  pkgs,
+  config,
+  modules,
+  ...
+}:
+let
+  cfg = config.programs.cosmic-osd;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+  libinput = pkgs.libinput.override (
+    lib.optionalAttrs (udevApi != null) {
+      udev = udevApi;
+      wacomSupport = false;
+    }
+  );
+in
+{
+  imports = [ modules.pipewire ];
+
+  options.programs.cosmic-osd = {
+    enable = lib.mkEnableOption "COSMIC OSD";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.cosmic-osd.override {
+        udev = udevApi;
+        inherit libinput;
+        pipewire = config.programs.pipewire.package;
+      };
+      defaultText = lib.literalExpression "pkgs.cosmic-osd";
+      description = ''
+        The package to use for `cosmic-osd`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/modules/programs/cosmic-session/default.nix
+++ b/modules/programs/cosmic-session/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  pkgs,
+  config,
+  modules,
+  ...
+}:
+let
+  cfg = config.programs.cosmic-session;
+in
+{
+  imports = [
+    modules.cosmic-settings
+    modules.cosmic-applets
+    modules.cosmic-comp
+  ];
+
+  options.programs.cosmic-session = {
+    enable = lib.mkEnableOption "COSMIC session";
+    package = lib.mkPackageOption pkgs "cosmic-session" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      # Necessary dependencies, `cosmic-session` crashes without them
+      pkgs.cosmic-notifications
+      pkgs.cosmic-panel
+    ];
+
+    programs = {
+      cosmic-settings.enable = true;
+      cosmic-comp.enable = true;
+      cosmic-applets.enable = true;
+    };
+  };
+}

--- a/modules/programs/cosmic-settings/default.nix
+++ b/modules/programs/cosmic-settings/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  pkgs,
+  config,
+  modules,
+  ...
+}:
+let
+  inherit (lib) types;
+  cfg = config.programs.cosmic-settings;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+  libinput = pkgs.libinput.override (
+    lib.optionalAttrs (udevApi != null) {
+      udev = udevApi;
+      wacomSupport = false;
+    }
+  );
+in
+{
+  imports = [
+    modules.pipewire
+  ];
+
+  options = {
+    programs.cosmic-settings = {
+      enable = lib.mkEnableOption "COSMIC settings";
+      package = lib.mkOption {
+        type = types.package;
+        default = pkgs.cosmic-settings.override {
+          udev = udevApi;
+          inherit libinput;
+          pipewire = config.programs.pipewire.package;
+        };
+        defaultText = lib.literalExpression "pkgs.cosmic-settings";
+        description = ''
+          The package to use for `cosmic-settings`.
+        '';
+      };
+      daemon.package = lib.mkOption {
+        type = types.package;
+        default = pkgs.cosmic-settings-daemon.override {
+          udev = udevApi;
+          inherit libinput;
+          pipewire = config.programs.pipewire.package;
+        };
+        defaultText = lib.literalExpression "pkgs.cosmic-settings-daemon";
+        description = ''
+          The package to use for `cosmic-settings-daemon`.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      cfg.daemon.package
+    ];
+  };
+}

--- a/modules/programs/cosmic-term/default.nix
+++ b/modules/programs/cosmic-term/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.cosmic-term;
+  inherit (lib) types;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+in
+{
+  options.programs.cosmic-term = {
+    enable = lib.mkEnableOption "COSMIC term";
+    package = lib.mkOption {
+      type = types.package;
+      default = pkgs.cosmic-term.override {
+        libinput = pkgs.libinput.override (
+          lib.optionalAttrs (udevApi != null) {
+            udev = udevApi;
+            wacomSupport = false;
+          }
+        );
+      };
+      defaultText = lib.literalExpression "pkgs.cosmic-term";
+      description = ''
+        The package to use for `cosmic-term`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+  };
+}

--- a/modules/programs/cosmic-workspaces-epoch/default.nix
+++ b/modules/programs/cosmic-workspaces-epoch/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.cosmic-workspaces-epoch;
+  udevApi =
+    if config.services.gardendevd.enable then
+      pkgs.libudev-garden
+    else if config.services.mdevd.enable || config.services.keventd.enable then
+      pkgs.libudev-zero
+    else
+      null;
+  libinput = pkgs.libinput.override (
+    lib.optionalAttrs (udevApi != null) {
+      udev = udevApi;
+      wacomSupport = false;
+    }
+  );
+in
+{
+  options.programs.cosmic-workspaces-epoch = {
+    enable = lib.mkEnableOption "COSMIC workspaces epoch";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.cosmic-workspaces-epoch.override {
+        udev = udevApi;
+        inherit libinput;
+      };
+      defaultText = lib.literalExpression "pkgs.cosmic-workspaces-epoch";
+      description = ''
+        The package to use for `cosmic-workspaces-epoch`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
+}


### PR DESCRIPTION
this change initializes `cosmic-session` and minimal set of programs needed to run it. This change doesn't include optional dependencies that can be started by `cosmic-session` like `cosmic-launcher`, `cosmic-idle` or icon/sound themes