### PR TITLE
modules: add `programs.sh` module; drop `users.defaultUserShell`, `environment.binsh`

### DIFF
--- a/modules/environment/default.nix
+++ b/modules/environment/default.nix
@@ -11,17 +11,6 @@ in
     ./shells
   ];
 
-  options.environment.binsh = lib.mkOption {
-    type = lib.types.path;
-    default = lib.getExe pkgs.dash;
-    defaultText = lib.literalExpression "lib.getExe pkgs.dash";
-    example = lib.literalExpression "lib.getExe pkgs.bashInteractive";
-    description = ''
-      Default shell linked system-wide to `/bin/sh`. Do your best to make sure any
-      modifications to this shell are POSIX-compliant.
-    '';
-  };
-
   config = {
     environment.systemPackages = [ finix-logo ];
     environment.etc."nsswitch.conf".text = ''

--- a/modules/environment/etc/default.nix
+++ b/modules/environment/etc/default.nix
@@ -5,6 +5,12 @@
   ...
 }:
 let
+  binShell =
+    if (config.programs.sh.enable or false) then
+      "${config.programs.sh.environmentShell}${config.programs.sh.environmentShell.shellPath}"
+    else
+      lib.getExe pkgs.dash;
+
   buildEtc =
     pkgs.runCommandLocal "etc"
       {
@@ -207,7 +213,7 @@ in
 
       # Create the required /bin/sh symlink; otherwise lots of things
       # (notably the system() function) won't work.
-      ln -sfn "${config.environment.binsh}" /bin/sh
+      ln -sfn "${binShell}" /bin/sh
     '';
   };
 }

--- a/modules/environment/path/default.nix
+++ b/modules/environment/path/default.nix
@@ -46,7 +46,6 @@
       util-linux
       which
 
-      bashInteractive
       gawk
       gnugrep
     ];

--- a/modules/programs/sh/default.nix
+++ b/modules/programs/sh/default.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.sh;
+  userShell = "${cfg.defaultUserShell}${cfg.defaultUserShell.shellPath}";
+in
+{
+  options.programs.sh = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable shell configuration.
+      '';
+    };
+
+    defaultUserShell = lib.mkOption {
+      type = lib.types.shellPackage;
+      default = pkgs.bashInteractive;
+      defaultText = lib.literalExpression "pkgs.bashInteractive";
+      example = lib.literalExpression "pkgs.fish";
+      description = ''
+        The shell package assigned to user accounts created with
+        {option} `isNormalUser = true`.
+      '';
+    };
+
+    environmentShell = lib.mkOption {
+      type = lib.types.shellPackage;
+      default = pkgs.dash;
+      defaultText = lib.literalExpression "pkgs.dash";
+      example = lib.literalExpression "pkgs.busybox";
+      description = ''
+        Default shell linked system-wide to /bin/sh. Any modifications 
+        are recommended to be POSIX-compliant.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.defaultUserShell ];
+    environment.shells = [
+      "/run/current-system/sw${cfg.defaultUserShell.shellPath}"
+      userShell
+    ];
+  };
+}

--- a/modules/users/options.nix
+++ b/modules/users/options.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.users;
+  systemConfig = config;
 in
 {
   options = {
@@ -49,7 +50,7 @@ in
                   This automatically sets {option}`group` to `users`,
                   {option}`createHome` to `true`,
                   {option}`home` to {file}`/home/«username»`,
-                  {option}`shell` to {option}`users.defaultUserShell`,
+                  {option}`shell` to {option}`programs.sh.defaultUserShell` if enabled or `bashInteractive` otherwise,
                   and {option}`isSystemUser` to `false`.
                   Exactly one of `isNormalUser` and `isSystemUser` must be true.
                 '';
@@ -178,7 +179,12 @@ in
                 group = lib.mkDefault "users";
                 createHome = lib.mkDefault true;
                 home = lib.mkDefault "/home/${config.name}";
-                shell = lib.mkDefault cfg.defaultUserShell;
+                shell = lib.mkDefault (
+                  if (systemConfig.programs.sh.enable or false) then
+                    systemConfig.programs.sh.defaultUserShell
+                  else
+                    pkgs.bashInteractive
+                );
                 isSystemUser = lib.mkDefault false;
               })
             ];
@@ -186,17 +192,6 @@ in
         )
       );
       default = { };
-    };
-
-    users.defaultUserShell = lib.mkOption {
-      type = with lib.types; either shellPackage (passwdEntry path);
-      default = pkgs.bashInteractive;
-      defaultText = lib.literalExpression "pkgs.bashInteractive";
-      example = lib.literalExpression "pkgs.zsh";
-      description = ''
-        The default shell assigned to user accounts created with
-        {option}`isNormalUser = true`.
-      '';
     };
 
     users.groups = lib.mkOption {


### PR DESCRIPTION
Discard `users.defaultUserShell` option.
Discard `environment.binsh` option.

Introduce `programs.sh` option instead. This contains options to set userspace shell (`programs.sh.defaultUserShell`) as well as the /bin/sh shell (`programs.sh.environmentShell`).

If not imported and/or enabled, user shell will default to `bashInteractive`. Meanwhile, environment shell will default to `dash`. Otherwise will use the shells set by this new module.