### PR TITLE
providers.privileges (doas): add missing 'args'

### DIFF
--- a/modules/programs/doas/providers.privileges.nix
+++ b/modules/programs/doas/providers.privileges.nix
@@ -25,10 +25,10 @@
           in
           ''
             ${lib.concatMapStringsSep "\n" (
-              user: "permit ${opts} ${user} ${runAs} cmd ${rule.command} ${toString rule.args}"
+              user: "permit ${opts} ${user} ${runAs} cmd ${rule.command} args ${toString rule.args}"
             ) rule.users}
             ${lib.concatMapStringsSep "\n" (
-              group: "permit ${opts} :${group} ${runAs} cmd ${rule.command} ${toString rule.args}"
+              group: "permit ${opts} :${group} ${runAs} cmd ${rule.command} args ${toString rule.args}"
             ) rule.groups}
           ''
         ) config.providers.privileges.rules


### PR DESCRIPTION
Privileges setup for `doas` misses `args` flag, meaning that rules written in the likes of:
```Nix
providers.privileges.rules = [
{
  users = [ "user" ];
  groups = [ ];
  runAs = "root";
  requirePassword = false;
  command = "/run/current-system/sw/bin/initctl";
  args = [ "suspend" ];
}
```
Will fail to build.