### PR TITLE
tree-wide: enable sysklogd in modules with reliance on it

### DIFF
--- a/modules/hardware/console.nix
+++ b/modules/hardware/console.nix
@@ -64,6 +64,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    services.sysklogd.enable = true;
     environment.systemPackages = [ pkgs.kbd ];
 
     # Include binary keymap in the initramfs.

--- a/modules/programs/ifupdown-ng/default.nix
+++ b/modules/programs/ifupdown-ng/default.nix
@@ -161,6 +161,7 @@ in
     programs.ifupdown-ng.extraArgs = [ "-a" ] ++ lib.optionals cfg.debug [ "-v" ];
 
     environment.systemPackages = [ cfg.package ];
+    services.sysklogd.enable = true;
 
     environment.etc."network/ifupdown-ng.conf".source = format.generate "ifupdown-ng.conf" cfg.settings;
     environment.etc."network/interfaces".text =

--- a/modules/services/acpid/default.nix
+++ b/modules/services/acpid/default.nix
@@ -58,6 +58,8 @@ in
       in
       lib.mkMerge [ etcTree ];
 
+    services.sysklogd.enable = true;
+
     finit.services.acpid = {
       description = "acpi daemon";
       conditions = "service/syslogd/ready";

--- a/modules/services/atd/default.nix
+++ b/modules/services/atd/default.nix
@@ -54,6 +54,8 @@ in
       text = lib.concatStringsSep "\n" cfg.deny;
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.atd = {
       description = "deferred execution scheduler";
       conditions = "service/syslogd/ready";

--- a/modules/services/autologin/default.nix
+++ b/modules/services/autologin/default.nix
@@ -67,6 +67,8 @@ in
       '';
     };
 
+    services.sysklogd.enable = true;
+
     # autologin is hardcoded to run on tty1
     finit.ttys.tty1.enable = lib.mkForce false;
 

--- a/modules/services/avahi/default.nix
+++ b/modules/services/avahi/default.nix
@@ -86,6 +86,8 @@ in
       # ${config.environment.etc."avahi/avahi-daemon.conf".source}
     '';
 
+    services.sysklogd.enable = true;
+
     finit.services.avahi-daemon = {
       description = "avahi daemon service";
       conditions = [

--- a/modules/services/blocky/default.nix
+++ b/modules/services/blocky/default.nix
@@ -85,6 +85,8 @@ in
       queryLog.type = lib.mkDefault "none";
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.blocky = {
       inherit (cfg) user group;
 

--- a/modules/services/chronyd/default.nix
+++ b/modules/services/chronyd/default.nix
@@ -89,6 +89,7 @@ in
     ];
 
     environment.systemPackages = [ cfg.package ];
+    services.sysklogd.enable = true;
 
     finit.services.chronyd = {
       description = "chrony ntp daemon";

--- a/modules/services/cron/default.nix
+++ b/modules/services/cron/default.nix
@@ -193,6 +193,7 @@ in
     environment.systemPackages = [
       cfg.package
     ];
+    services.sysklogd.enable = true;
 
     finit.tmpfiles.rules = [
       "d /var/cron 0710"

--- a/modules/services/dbus/default.nix
+++ b/modules/services/dbus/default.nix
@@ -105,6 +105,7 @@ in
     environment.systemPackages = [
       cfg.package
     ];
+    services.sysklogd.enable = true;
 
     services.dbus.packages = [
       cfg.package

--- a/modules/services/dhcpcd/default.nix
+++ b/modules/services/dhcpcd/default.nix
@@ -169,6 +169,8 @@ in
       (toString cfg.configFile)
     ];
 
+    services.sysklogd.enable = true;
+
     services.dhcpcd.settings = {
       # Inform the DHCP server of our hostname for DDNS.
       hostname = "";

--- a/modules/services/docker/default.nix
+++ b/modules/services/docker/default.nix
@@ -237,6 +237,8 @@ in
       docker = { };
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.docker = {
       description = "docker daemon";
       conditions = [

--- a/modules/services/dropbear/default.nix
+++ b/modules/services/dropbear/default.nix
@@ -135,6 +135,8 @@ in
         pkgs.writeShellScript "ssh-keygen.sh" script;
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.dropbear = {
       description = "dropbear ssh daemon";
       conditions = [

--- a/modules/services/earlyoom/default.nix
+++ b/modules/services/earlyoom/default.nix
@@ -51,6 +51,8 @@ in
   config = lib.mkIf cfg.enable {
     services.earlyoom.extraArgs = [ "-p" ] ++ lib.optionals cfg.debug [ "--debug" ];
 
+    services.sysklogd.enable = true;
+
     finit.services.earlyoom = {
       description = "early oom daemon";
       command = "${cfg.package}/bin/earlyoom --syslog " + lib.escapeShellArgs cfg.extraArgs;

--- a/modules/services/fcron/default.nix
+++ b/modules/services/fcron/default.nix
@@ -197,6 +197,8 @@ in
       };
     };
 
+    services.sysklogd.enable = true;
+
     finit.tasks.fcrontab = {
       description = "reload fcrontab";
       conditions = [

--- a/modules/services/greetd/default.nix
+++ b/modules/services/greetd/default.nix
@@ -40,6 +40,8 @@ in
       };
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.greetd = {
       description = "greeter daemon";
       runlevels = "34";

--- a/modules/services/illum/default.nix
+++ b/modules/services/illum/default.nix
@@ -41,6 +41,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    services.sysklogd.enable = true;
     finit.services.illum = {
       description = "backlight adjustment service";
       command = lib.getExe cfg.package;

--- a/modules/services/incus/default.nix
+++ b/modules/services/incus/default.nix
@@ -39,6 +39,7 @@ in
     environment.systemPackages = [
       cfg.package
     ];
+    services.sysklogd.enable = true;
 
     finit.services.incusd = {
       description = "incus container hypervisor";

--- a/modules/services/iwd/default.nix
+++ b/modules/services/iwd/default.nix
@@ -68,6 +68,8 @@ in
       "d /var/lib/iwd 0700"
     ];
 
+    services.sysklogd.enable = true;
+
     finit.services.iwd = {
       description = "wireless service";
       conditions = "service/syslogd/ready";

--- a/modules/services/jellyfin/default.nix
+++ b/modules/services/jellyfin/default.nix
@@ -70,6 +70,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    services.sysklogd.enable = true;
     finit.services.jellyfin = {
       inherit (cfg) user group;
 

--- a/modules/services/keyd/default.nix
+++ b/modules/services/keyd/default.nix
@@ -122,6 +122,7 @@ in
 
   config = lib.mkIf cfg.enable {
     hardware.uinput.enable = true;
+    services.sysklogd.enable = true;
 
     environment.etc =
       let

--- a/modules/services/lemurs/default.nix
+++ b/modules/services/lemurs/default.nix
@@ -124,6 +124,8 @@ in
     # disable the tty that lemurs runs on
     finit.ttys."tty${toString cfg.settings.tty}".enable = false;
 
+    services.sysklogd.enable = true;
+
     finit.services.lemurs = {
       description = "lemurs terminal user interface display/login manager";
       conditions = "service/syslogd/ready";

--- a/modules/services/ly/default.nix
+++ b/modules/services/ly/default.nix
@@ -113,6 +113,7 @@ in
 
     # Disable the tty that ly runs on
     finit.ttys."tty${toString cfg.tty}".enable = false;
+    services.sysklogd.enable = true;
 
     finit.services.ly = {
       description = "ly terminal display/login manager";

--- a/modules/services/mariadb/default.nix
+++ b/modules/services/mariadb/default.nix
@@ -136,6 +136,8 @@ in
       };
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.mariadb = {
       inherit (cfg) user group;
 

--- a/modules/services/nftables/default.nix
+++ b/modules/services/nftables/default.nix
@@ -46,6 +46,8 @@ in
     };
   };
 
+  services.sysklogd.enable = true;
+
   config = lib.mkIf cfg.enable {
     # boot.blacklistedKernelModules = [ "ip_tables" ];
 

--- a/modules/services/nix-daemon/default.nix
+++ b/modules/services/nix-daemon/default.nix
@@ -278,6 +278,7 @@ in
 
   config = lib.mkIf cfg.enable {
     environment.etc."nix/nix.conf".source = configFile;
+    services.sysklogd.enable = true;
 
     finit.services.nix-daemon = {
       description = "nix daemon";

--- a/modules/services/nzbget/default.nix
+++ b/modules/services/nzbget/default.nix
@@ -114,6 +114,8 @@ in
       UpdateCheck = "none";
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.nzbget =
       let
         configOpts = lib.concatStringsSep " " (

--- a/modules/services/openssh/default.nix
+++ b/modules/services/openssh/default.nix
@@ -308,6 +308,8 @@ in
       '';
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.sshd = {
       description = "openssh daemon";
       conditions = [

--- a/modules/services/php-fpm/default.nix
+++ b/modules/services/php-fpm/default.nix
@@ -126,6 +126,8 @@ in
     };
   };
 
+  services.sysklogd.enable = true;
+
   config = lib.mkIf cfg.enable {
     services.php-fpm.settings = {
       error_log = "syslog";

--- a/modules/services/postgresql/default.nix
+++ b/modules/services/postgresql/default.nix
@@ -144,6 +144,8 @@ in
       # ${config.environment.etc."postgresql/${cfg.package.psqlSchema}/pg_ident.conf".source}
     '';
 
+    services.sysklogd.enable = true;
+
     finit.services.postgresql = {
       inherit (cfg) user group;
 

--- a/modules/services/radarr/default.nix
+++ b/modules/services/radarr/default.nix
@@ -143,6 +143,8 @@ in
     };
   };
 
+  services.sysklogd.enable = true;
+
   config = lib.mkIf cfg.enable {
     finit.tmpfiles.rules = lib.optionals (cfg.dataDir == "/var/lib/radarr") [
       "d ${cfg.dataDir} 0700 ${cfg.user} ${cfg.group}"

--- a/modules/services/sddm/default.nix
+++ b/modules/services/sddm/default.nix
@@ -147,6 +147,8 @@ in
       "/share/sddm"
     ];
 
+    services.sysklogd.enable = true;
+
     providers.privileges.rules = lib.mkIf config.services.seatd.enable [
       {
         command = "/run/current-system/sw/bin/reboot";

--- a/modules/services/seatd/default.nix
+++ b/modules/services/seatd/default.nix
@@ -44,6 +44,8 @@ in
       seat = { };
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.seatd = {
       description = "seat management daemon";
       runlevels = "34";

--- a/modules/services/sonarr/default.nix
+++ b/modules/services/sonarr/default.nix
@@ -148,6 +148,8 @@ in
       "d ${cfg.dataDir} 0700 ${cfg.user} ${cfg.group}"
     ];
 
+    services.sysklogd.enable = true;
+
     finit.services.sonarr = {
       inherit (cfg) user group;
 

--- a/modules/services/sshguard/default.nix
+++ b/modules/services/sshguard/default.nix
@@ -93,6 +93,8 @@ in
       )
     );
 
+    services.sysklogd.enable = true;
+
     finit.services.sshguard = {
       command = lib.getExe cfg.package;
       conditions = [

--- a/modules/services/thermald/default.nix
+++ b/modules/services/thermald/default.nix
@@ -53,6 +53,7 @@ in
     ++ lib.optionals cfg.debug [ "--loglevel=debug" ];
 
     services.dbus.packages = [ cfg.package ];
+    services.sysklogd.enable = true;
 
     finit.services.thermald = {
       description = "thermal daemon service";

--- a/modules/services/tlp/default.nix
+++ b/modules/services/tlp/default.nix
@@ -79,6 +79,8 @@ in
       # -SUBSYSTEM=block;DEVTYPE=disk;.* root:root 0600 +${cfg.package}/lib/udev/tlp-usb-udev disk /sys/$DEVPATH
     '';
 
+    services.sysklogd.enable = true;
+
     finit.tasks = {
       "tlp@start" = {
         description = "tlp system startup";

--- a/modules/services/tzupdate/default.nix
+++ b/modules/services/tzupdate/default.nix
@@ -37,6 +37,7 @@ in
 
   config = lib.mkIf cfg.enable {
     time.timeZone = null;
+    services.sysklogd.enable = true;
 
     finit.tasks.tzupdate = {
       description = "timezone update service";

--- a/modules/services/uptime-kuma/default.nix
+++ b/modules/services/uptime-kuma/default.nix
@@ -98,6 +98,8 @@ in
       NODE_ENV = "production";
     };
 
+    services.sysklogd.enable = true;
+
     finit.services.uptime-kuma = {
       inherit (cfg) user group;
 

--- a/modules/services/vnstat/default.nix
+++ b/modules/services/vnstat/default.nix
@@ -136,6 +136,8 @@ in
       "d ${cfg.settings.DatabaseDir} 0750 ${cfg.user} ${cfg.group}"
     ];
 
+    services.sysklogd.enable = true;
+
     finit.services.vnstat = {
       inherit (cfg) user group;
 

--- a/modules/services/zerotierone/default.nix
+++ b/modules/services/zerotierone/default.nix
@@ -50,6 +50,8 @@ in
       cfg.package
     ];
 
+    services.sysklogd.enable = true;
+
     finit.services.zerotierone = {
       description = "zerotier one";
       conditions = [


### PR DESCRIPTION
Inspired by the not-so-pleasant situation where a display manager like `ly` will never launch because it expects `syslogd` to be ready. This will never occur since a user has to manually enable `services.sysklogd`. This PR adds enabling of `sysklogd` to every module that relies on it.