### PR TITLE
modules/autologin: add `sessiond` condition to fix race

### DIFF
--- a/modules/services/autologin/default.nix
+++ b/modules/services/autologin/default.nix
@@ -84,6 +84,7 @@ in
       conditions = [
         "service/syslogd/ready"
       ]
+      ++ lib.optionals config.services.sessiond.enable [ "service/sessiond/ready" ]
       ++ lib.optionals config.services.elogind.enable [ "service/elogind/ready" ]
       ++ lib.optionals config.services.seatd.enable [ "service/seatd/ready" ];
       log = true;

--- a/modules/services/greetd/default.nix
+++ b/modules/services/greetd/default.nix
@@ -56,6 +56,7 @@ in
       conditions = [
         "service/syslogd/ready"
       ]
+      ++ lib.optionals config.services.sessiond.enable [ "service/sessiond/ready" ]
       ++ lib.optionals config.services.elogind.enable [ "service/elogind/ready" ]
       ++ lib.optionals config.services.seatd.enable [ "service/seatd/ready" ];
       command = "${pkgs.greetd}/bin/greetd --config ${configFile}";

--- a/modules/services/sddm/default.nix
+++ b/modules/services/sddm/default.nix
@@ -176,6 +176,7 @@ in
       conditions = [
         "service/syslogd/ready"
       ]
+      ++ lib.optionals config.services.sessiond.enable [ "service/sessiond/ready" ]
       ++ lib.optionals config.services.elogind.enable [ "service/elogind/ready" ]
       ++ lib.optionals config.services.seatd.enable [ "service/seatd/ready" ];
       command = "/run/current-system/sw/bin/sddm";


### PR DESCRIPTION
missing ordering caused a startup race between `sessiond` and `autologin` resulting in session not being registered