### PR TITLE
modules/services/tlp: add tlp-pd

### DIFF
--- a/modules/services/tlp/default.nix
+++ b/modules/services/tlp/default.nix
@@ -3,17 +3,15 @@
   lib,
   pkgs,
   ...
-}:
-let
+}: let
   cfg = config.services.tlp;
   tlpExe = lib.getExe cfg.package;
 
   format = pkgs.formats.keyValue {
-    mkKeyValue = lib.generators.mkKeyValueDefault { } "=";
+    mkKeyValue = lib.generators.mkKeyValueDefault {} "=";
     listToValue = l: "\"${toString l}\"";
   };
-in
-{
+in {
   options.services.tlp = {
     enable = lib.mkOption {
       type = lib.types.bool;
@@ -32,9 +30,27 @@ in
       '';
     };
 
+    pd = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable tlp-pd, a power-profile-daemon like DBus interface for TLP.
+        '';
+      };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.tlp-pd;
+        defaultText = lib.literalExpression "pkgs.tlp-pd";
+        description = ''
+          The package to use for `tlp-pd`.
+        '';
+      };
+    };
+
     settings = lib.mkOption {
       type = format.type;
-      default = { };
+      default = {};
       description = ''
         `tlp` configuration. See [upstream documentation](https://linrunner.de/tlp/settings)
         for additional details.
@@ -45,9 +61,11 @@ in
   config = lib.mkIf cfg.enable {
     environment.etc."tlp.conf".source = format.generate "tlp.conf" cfg.settings;
 
-    environment.systemPackages = [
-      cfg.package
-    ];
+    environment.systemPackages =
+      [
+        cfg.package
+      ]
+      ++ lib.optionals cfg.pd.enable [cfg.pd.package];
 
     finit.tmpfiles.rules = [
       "d /var/lib/tlp"
@@ -65,7 +83,7 @@ in
       };
     };
 
-    services.udev.packages = [ cfg.package ];
+    services.udev.packages = [cfg.package];
 
     # TODO: revisit rules... compare with udev
     services.mdevd.hotplugRules = ''
@@ -99,6 +117,12 @@ in
         conditions = "service/syslogd/ready";
         runlevels = "06";
       };
+    };
+
+    finit.services.tlp-pd = {
+      description = "tlp-pd service";
+      command = lib.getExe cfg.pd.package;
+      runlevels = "2345";
     };
 
     # TODO: add finit.services.restartTriggers option


### PR DESCRIPTION
adds options and finit service for tlp-pd. power profiles daemon like dbus interface for tlp

I used the nixos module for reference and tried to make the options the same way as how other ones are defined in finix.
note that tlp-pd shouldn't be enabled with power-profiles-daemon since it uses the same dbus interface as it. The nixos module uses an assertion to stop that from happening but i didn't see those being used in finix for options that live in separate modules so i didn't add that.