### PR TITLE
setup-etc.sh: fix mktemp failures caused by leaked TMPDIR

### DIFF
--- a/modules/environment/etc/setup-etc.sh
+++ b/modules/environment/etc/setup-etc.sh
@@ -19,6 +19,9 @@ fi
 # Ensure /tmp exists for mktemp (specialfs activation runs after us).
 mkdir -p /tmp
 
+# TMPDIR may leak in from outside the chroot (e.g. nixos-install sets it before chrooting into /mnt) pointing mktemp at a path that doesn't exist
+unset TMPDIR
+
 # Atomically update /etc/static to point at current configuration's etc.
 ln -sfn "$etc" "$static"
 


### PR DESCRIPTION
`TMPDIR` leaked in from before the chroot into `/mnt` so mktemp pointed at a path that didn't exist inside the chroot silently skipping the whole `/etc` symlink setup

Now unsets TMPDIR at the top of the script so mktemp uses `/tmp`