### PR TITLE
fix(getty): missing ESC byte breaks color in welcome banner

### DIFF
--- a/modules/services/getty/default.nix
+++ b/modules/services/getty/default.nix
@@ -57,7 +57,7 @@ in
     environment.etc.issue = lib.mkDefault {
       text = ''
 
-        [1;32m<<< welcome to finix >>>[0m
+        ${"\e"}[1;32m<<< welcome to finix >>>${"\e"}[0m
 
       '';
     };


### PR DESCRIPTION
There was a missing `\x1b` byte before the ANSI codes so `[1;32m`/`[0m` were rendered as literal text instead of coloring the banner