### PR TITLE
fix(shadow): PAM hardcodes yescrypt instead of using ENCRYPT_METHOD

### DIFF
--- a/modules/programs/shadow/default.nix
+++ b/modules/programs/shadow/default.nix
@@ -11,6 +11,8 @@ let
     mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
   };
 
+  encryptMethod = lib.toLower cfg.settings.ENCRYPT_METHOD;
+
   session_rundir =
     if config.services.sessiond.enable then
       "session optional ${config.services.sessiond.package}/lib/security/pam_sessiond.so"
@@ -168,7 +170,7 @@ in
         auth required pam_deny.so # deny (order 13600)
 
         # Password management.
-        password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
+        password sufficient pam_unix.so nullok ${encryptMethod} # unix (order 10200)
 
         # Session management.
         session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
@@ -193,7 +195,7 @@ in
         auth required pam_deny.so # deny (order 12300)
 
         # Password management.
-        password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
+        password sufficient pam_unix.so nullok ${encryptMethod} # unix (order 10200)
 
         # Session management.
         session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
@@ -215,7 +217,7 @@ in
         auth required pam_deny.so # deny (order 12300)
 
         # Password management.
-        password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
+        password sufficient pam_unix.so nullok ${encryptMethod} # unix (order 10200)
 
         # Session management.
         session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)


### PR DESCRIPTION
PAM password lines for `login`/`su`/`passwd` had `yescrypt` hardcoded regardless of `ENCRYPT_METHOD` in `login.defs`, causing a mismatch and false "insecure hashing" warning on new accounts